### PR TITLE
Abstract getLocalBoundingBox on BaseObject

### DIFF
--- a/packages/core/src/objects/BaseObject.ts
+++ b/packages/core/src/objects/BaseObject.ts
@@ -149,12 +149,24 @@ export abstract class BaseObject {
   }
 
   /**
-   * Axis-aligned bounding box in local space (before world transform).
-   * Subclasses may override for non-rectangular shapes.
+   * Axis-aligned bounding box in local (parent) space, **before** the world
+   * transform is applied.
+   *
+   * Every concrete object type MUST implement this method. There is no default
+   * because the shape of the bounding box is intrinsic to the object's geometry:
+   *
+   * - Rectangularly-positioned objects (Rect, Circle, Text, Image) return
+   *   `new BoundingBox(0, 0, this.width, this.height)` — the transform (x, y,
+   *   rotation, scale) is separate and applied by `getWorldBoundingBox()`.
+   * - Geometry-defined objects (Line, Path, connectors) compute the bbox
+   *   directly from their geometry data (endpoints, path `d` string, waypoints)
+   *   without relying on `x / y / width / height`.
+   *
+   * Making this abstract guarantees that authors of new object types must
+   * consciously declare how their bounding box is computed, preventing silent
+   * 0×0 fallbacks that cause culling and hit-testing failures (NV-027).
    */
-  getLocalBoundingBox(): BoundingBox {
-    return new BoundingBox(0, 0, this.width, this.height)
-  }
+  abstract getLocalBoundingBox(): BoundingBox
 
   /**
    * Axis-aligned bounding box in world space. Result is cached; cleared on any spatial mutation.

--- a/packages/core/src/objects/CanvasImage.ts
+++ b/packages/core/src/objects/CanvasImage.ts
@@ -1,4 +1,5 @@
 import { BaseObject, type BaseObjectProps } from './BaseObject.js'
+import { BoundingBox } from '../math/BoundingBox.js'
 import type { RenderContext, ObjectJSON } from '../types.js'
 import type { PaintCK } from '../renderer/paint.js'
 
@@ -67,6 +68,10 @@ export class CanvasImage extends BaseObject {
 
   getType(): string {
     return 'Image'
+  }
+
+  getLocalBoundingBox(): BoundingBox {
+    return new BoundingBox(0, 0, this.width, this.height)
   }
 
   private _startLoad(ck: ImageCK): void {

--- a/packages/core/src/objects/Circle.ts
+++ b/packages/core/src/objects/Circle.ts
@@ -1,4 +1,5 @@
 import { BaseObject, type BaseObjectProps } from './BaseObject.js'
+import { BoundingBox } from '../math/BoundingBox.js'
 import { makeFillPaint, makeStrokePaint, type PaintCK } from '../renderer/paint.js'
 import type { RenderContext, ObjectJSON } from '../types.js'
 
@@ -71,6 +72,10 @@ export class Circle extends BaseObject {
 
   getType(): string {
     return 'Circle'
+  }
+
+  getLocalBoundingBox(): BoundingBox {
+    return new BoundingBox(0, 0, this.width, this.height)
   }
 
   render(ctx: RenderContext): void {

--- a/packages/core/src/objects/Group.ts
+++ b/packages/core/src/objects/Group.ts
@@ -83,6 +83,27 @@ export class Group extends BaseObject {
   // Transform & bounds
   // ---------------------------------------------------------------------------
 
+  /**
+   * Local bounding box of this group: the union of all visible children's
+   * bounding boxes expressed in the group's own coordinate space.
+   *
+   * Unlike `getWorldBoundingBox()` (which operates in world space), this
+   * method applies only each child's local transform — leaving the group's
+   * own x/y/rotation out of the result. That keeps the contract consistent
+   * with how all other objects define their local bbox (shape at the origin,
+   * transform applied separately by `getWorldBoundingBox()`).
+   */
+  getLocalBoundingBox(): BoundingBox {
+    if (this._children.length === 0) return new BoundingBox(0, 0, 0, 0)
+    let result: BoundingBox | null = null
+    for (const child of this._children) {
+      if (!child.visible) continue
+      const childBB = child.getLocalBoundingBox().transform(child.getLocalTransform())
+      result = result === null ? childBB : result.union(childBB)
+    }
+    return result ?? new BoundingBox(0, 0, 0, 0)
+  }
+
   /** Group's world bbox is the union of all visible children's world bounding boxes. */
   protected override _computeWorldBoundingBox(): BoundingBox {
     if (this._children.length === 0) {

--- a/packages/core/src/objects/Rect.ts
+++ b/packages/core/src/objects/Rect.ts
@@ -1,4 +1,5 @@
 import { BaseObject, type BaseObjectProps } from './BaseObject.js'
+import { BoundingBox } from '../math/BoundingBox.js'
 import { makeFillPaint, makeStrokePaint, type PaintCK } from '../renderer/paint.js'
 import type { RenderContext, ObjectJSON } from '../types.js'
 
@@ -32,6 +33,10 @@ export class Rect extends BaseObject {
 
   getType(): string {
     return 'Rect'
+  }
+
+  getLocalBoundingBox(): BoundingBox {
+    return new BoundingBox(0, 0, this.width, this.height)
   }
 
   render(ctx: RenderContext): void {

--- a/packages/core/src/objects/Text.ts
+++ b/packages/core/src/objects/Text.ts
@@ -1,4 +1,5 @@
 import { BaseObject, type BaseObjectProps } from './BaseObject.js'
+import { BoundingBox } from '../math/BoundingBox.js'
 import { colorToCK, type PaintCK } from '../renderer/paint.js'
 import type { RenderContext, ObjectJSON } from '../types.js'
 
@@ -111,6 +112,10 @@ export class Text extends BaseObject {
 
   getType(): string {
     return 'Text'
+  }
+
+  getLocalBoundingBox(): BoundingBox {
+    return new BoundingBox(0, 0, this.width, this.height)
   }
 
   /** Invalidate the cached paragraph (call after changing text or style props). */

--- a/packages/core/tests/objects/Group.test.ts
+++ b/packages/core/tests/objects/Group.test.ts
@@ -134,4 +134,47 @@ describe('Group', () => {
     expect(g.children).toHaveLength(0)
     expect(r.parent).toBeNull()
   })
+
+  // NV-027 — getLocalBoundingBox must be computed from children, not from
+  // Group's own x/y/width/height fields (which are semantically meaningless
+  // for a Group that simply contains other objects).
+  describe('getLocalBoundingBox (NV-027)', () => {
+    it('returns zero-size box for an empty group', () => {
+      const g = new Group()
+      const bbox = g.getLocalBoundingBox()
+      expect(bbox.width).toBe(0)
+      expect(bbox.height).toBe(0)
+    })
+
+    it('returns the union of children local bboxes', () => {
+      const g = new Group()
+      g.add(new Rect({ x: 10, y: 10, width: 50, height: 30 }))
+      g.add(new Rect({ x: 70, y: 20, width: 40, height: 20 }))
+      // children span x∈[10,110], y∈[10,40] in group-local space
+      const bbox = g.getLocalBoundingBox()
+      expect(bbox.x).toBe(10)
+      expect(bbox.y).toBe(10)
+      expect(bbox.right).toBe(110)
+      expect(bbox.bottom).toBe(40)
+    })
+
+    it('ignores invisible children', () => {
+      const g = new Group()
+      g.add(new Rect({ x: 10, y: 10, width: 50, height: 30 }))
+      g.add(new Rect({ x: 200, y: 200, width: 50, height: 50, visible: false }))
+      const bbox = g.getLocalBoundingBox()
+      expect(bbox.right).toBeLessThan(200)
+    })
+
+    it('accounts for child local transforms', () => {
+      const g = new Group()
+      // Child is offset by (20, 30) in the group's local space
+      g.add(new Rect({ x: 20, y: 30, width: 60, height: 40 }))
+      const bbox = g.getLocalBoundingBox()
+      expect(bbox.x).toBe(20)
+      expect(bbox.y).toBe(30)
+      expect(bbox.right).toBe(80)
+      expect(bbox.bottom).toBe(70)
+    })
+  })
 })

--- a/packages/core/tests/objects/Rect.test.ts
+++ b/packages/core/tests/objects/Rect.test.ts
@@ -128,4 +128,15 @@ describe('Rect', () => {
     expect(bb.width).toBeCloseTo(80)
     expect(bb.height).toBeCloseTo(40)
   })
+
+  // NV-027 — each concrete object must declare its own local bbox explicitly
+  it('getLocalBoundingBox returns (0, 0, width, height) in local space', () => {
+    const rect = new Rect({ x: 50, y: 100, width: 80, height: 40 })
+    const bb = rect.getLocalBoundingBox()
+    // local bbox origin is always 0,0 — position (x,y) is part of the transform, not the bbox
+    expect(bb.x).toBe(0)
+    expect(bb.y).toBe(0)
+    expect(bb.width).toBe(80)
+    expect(bb.height).toBe(40)
+  })
 })


### PR DESCRIPTION

Fixes #3 

## Root cause

`BaseObject.getLocalBoundingBox()` had a concrete default implementation that returned `new BoundingBox(0, 0, this.width, this.height)`. This created an implicit coupling between the positional fields (`x`, `y`, `width`, `height`) and the bounding box contract that every object inherits.

For objects whose geometry is _not_ defined by a rectangular position + size — connectors, arrows, freehand paths, polylines — this caused two real problems:

1. **Silent 0×0 bounding box.** Any custom object that forgot to override `getLocalBoundingBox()` would silently inherit a zero-size box if it didn't explicitly set `width`/`height`. A 0×0 box means the object is always culled by the viewport and is never hit-testable — the object effectively disappears without any error.

2. **`Group` was actually buggy.** `Group` overrides `_computeWorldBoundingBox()` to compute from children's world bboxes, but it _never_ overrode `getLocalBoundingBox()`. So `group.getLocalBoundingBox()` always returned `BoundingBox(0, 0, 0, 0)` for any group where `width`/`height` weren't set explicitly — a silent incorrect result.

The root cause was the same in both cases: the base class provided a default that made a geometric assumption about all subclasses.

## Solution
`getLocalBoundingBox()` is now **abstract** on `BaseObject`.

There is no default. Every concrete object type must explicitly declare how its bounding box is computed. The contract is documented on the abstract method itself.

This was preferred over:
- Keeping the default and adding a lint rule (invisible to contributors, not enforced by the compiler).
- Introducing an intermediate `PositionedObject` subclass that carries `x/y/width/height` (a larger structural refactor deferred to a future milestone when there is a concrete custom-object use case to design against).

Making it abstract is a one-line change to the base class with clear, immediate enforcement at the TypeScript level — exactly the kind of API constraint that should live in the type system, not in documentation.