### PR TITLE
Fix text invalidattion

### DIFF
--- a/packages/core/src/objects/Text.ts
+++ b/packages/core/src/objects/Text.ts
@@ -85,14 +85,40 @@ interface TextCK extends PaintCK {
 
 /** Single or multi-line text object. Rendered via CanvasKit's paragraph API for proper shaping. */
 export class Text extends BaseObject {
-  text: string
-  fontFamily: string
-  fontSize: number
-  fontWeight: number
-  fontStyle: 'normal' | 'italic'
-  align: TextAlign
-  baseline: TextBaseline
-  lineHeight: number
+  // Backing fields — mutated only through setters so the paragraph cache is
+  // automatically invalidated on every property change (NV-014).
+  private _text: string = ''
+  private _fontFamily: string = 'Noto Sans'
+  private _fontSize: number = 16
+  private _fontWeight: number = 400
+  private _fontStyle: 'normal' | 'italic' = 'normal'
+  private _align: TextAlign = 'left'
+  private _baseline: TextBaseline = 'top'
+  private _lineHeight: number = 1.2
+
+  get text(): string { return this._text }
+  set text(v: string) { this._text = v; this.invalidate() }
+
+  get fontFamily(): string { return this._fontFamily }
+  set fontFamily(v: string) { this._fontFamily = v; this.invalidate() }
+
+  get fontSize(): number { return this._fontSize }
+  set fontSize(v: number) { this._fontSize = v; this.invalidate() }
+
+  get fontWeight(): number { return this._fontWeight }
+  set fontWeight(v: number) { this._fontWeight = v; this.invalidate() }
+
+  get fontStyle(): 'normal' | 'italic' { return this._fontStyle }
+  set fontStyle(v: 'normal' | 'italic') { this._fontStyle = v; this.invalidate() }
+
+  get align(): TextAlign { return this._align }
+  set align(v: TextAlign) { this._align = v; this.invalidate() }
+
+  get baseline(): TextBaseline { return this._baseline }
+  set baseline(v: TextBaseline) { this._baseline = v; this.invalidate() }
+
+  get lineHeight(): number { return this._lineHeight }
+  set lineHeight(v: number) { this._lineHeight = v; this.invalidate() }
 
   /** Cached paragraph — invalidated when text or style properties change. */
   private _paragraph: SkParagraph | null = null
@@ -100,14 +126,16 @@ export class Text extends BaseObject {
 
   constructor(props: TextProps = {}) {
     super(props)
-    this.text = props.text ?? ''
-    this.fontFamily = props.fontFamily ?? 'Noto Sans'
-    this.fontSize = props.fontSize ?? 16
-    this.fontWeight = props.fontWeight ?? 400
-    this.fontStyle = props.fontStyle ?? 'normal'
-    this.align = props.align ?? 'left'
-    this.baseline = props.baseline ?? 'top'
-    this.lineHeight = props.lineHeight ?? 1.2
+    // Assign directly to backing fields to avoid triggering invalidate() during
+    // construction (paragraph is already null at this point).
+    this._text = props.text ?? ''
+    this._fontFamily = props.fontFamily ?? 'Noto Sans'
+    this._fontSize = props.fontSize ?? 16
+    this._fontWeight = props.fontWeight ?? 400
+    this._fontStyle = props.fontStyle ?? 'normal'
+    this._align = props.align ?? 'left'
+    this._baseline = props.baseline ?? 'top'
+    this._lineHeight = props.lineHeight ?? 1.2
   }
 
   getType(): string {

--- a/packages/core/tests/objects/Text.test.ts
+++ b/packages/core/tests/objects/Text.test.ts
@@ -76,4 +76,88 @@ describe('Text', () => {
     text.render(ctx)
     expect(canvas.calls.length).toBeGreaterThan(callsAfterFirst)
   })
+
+  describe('auto-invalidation on property set (NV-014)', () => {
+    function countBuilds(ctx: RenderContext, ck: ReturnType<typeof createMockCK>) {
+      const buildSpy = vi.spyOn(ck.ParagraphBuilder, 'MakeFromFontProvider')
+      return buildSpy
+    }
+
+    it('rebuilds paragraph when .text is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hello', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.text = 'World'
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('rebuilds paragraph when .fontSize is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hi', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.fontSize = 32
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('rebuilds paragraph when .fontFamily is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hi', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.fontFamily = 'Roboto'
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('rebuilds paragraph when .fontWeight is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hi', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.fontWeight = 700
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('rebuilds paragraph when .fontStyle is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hi', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.fontStyle = 'italic'
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('rebuilds paragraph when .align is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hi', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.align = 'center'
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('rebuilds paragraph when .lineHeight is set without calling invalidate()', () => {
+      const { ctx, ck } = makeCtx(true)
+      const spy = countBuilds(ctx, ck)
+      const text = new Text({ text: 'Hi', x: 0, y: 0, width: 200, height: 50 })
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(1)
+      text.lineHeight = 1.5
+      text.render(ctx)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+  })
 })


### PR DESCRIPTION
Fixes #5 

## Summary

`Text` properties (`text`, `fontFamily`, `fontSize`, `fontWeight`, `fontStyle`, `align`, `baseline`, `lineHeight`) were plain public fields. Mutating them left the internally cached `SkParagraph` stale until the caller remembered to call `obj.invalidate()` manually — a footgun that caused silent mis-renders.

## Approach

Converted all paragraph-affecting properties from plain public fields to private backing fields exposed through getter/setter pairs. Each setter delegates to `this.invalidate()`, which deletes the stale `SkParagraph` and resets the layout-width sentinel. Construction assigns directly to the backing fields (bypasses setters) so no redundant `invalidate()` calls occur before the first render.

The `invalidate()` method itself is unchanged and remains public for callers that batch multiple mutations and want a single explicit flush (no regression for existing code that already calls it).

## Decisions

- **Getters/setters over `Proxy`**: Proxy adds runtime overhead on every property access. Explicit getters/setters are zero-cost for reads and well-understood by TypeScript's type system.
- **Bypass setters in constructor**: The paragraph cache is `null` at construction time, so calling `invalidate()` 8× would be a no-op with extra overhead. Assigning directly to backing fields is safe and explicit.
- **`baseline` included**: `baseline` only affects the draw-position offset, not the paragraph content. Auto-invalidating it on change is conservative but correct; the cost of an extra paragraph build when switching `baseline` is negligible.
- **`fill` not included**: `fill` is inherited from `BaseObject` as a plain field. Overriding a base-class field with an accessor in a subclass is not valid TypeScript (TS2611). Handling `fill` auto-invalidation would require changing `BaseObject`, which is a separate concern.

## Tests

Seven new `it()` cases added under a `describe('auto-invalidation on property set (NV-014)')` block in `Text.test.ts`. Each case:
1. Renders the text once (builds the paragraph — spy count = 1).
2. Mutates a single property **without** calling `invalidate()`.
3. Renders again and asserts the spy count rose to 2, proving the paragraph was rebuilt automatically.