### PR TITLE
Add mutation event system

### DIFF
--- a/packages/core/src/Layer.ts
+++ b/packages/core/src/Layer.ts
@@ -29,6 +29,7 @@ export class Layer {
 
   private _objects: BaseObject[] = []
   private _onObjectMutation: ((type: 'added' | 'removed', obj: BaseObject) => void) | null = null
+  private _onPropertyMutation: ((obj: BaseObject, property: string, oldValue: unknown, newValue: unknown) => void) | null = null
   private _index = new RBush<RBushItem>()
   private _indexItems = new Map<BaseObject, RBushItem>()
 
@@ -58,12 +59,26 @@ export class Layer {
     this._onObjectMutation = fn
   }
 
+  /**
+   * Register a callback invoked when an object's properties change.
+   * Used internally by Stage to emit `object:mutated` stage events.
+   * @internal
+   */
+  setPropertyMutationHandler(
+    fn: ((obj: BaseObject, property: string, oldValue: unknown, newValue: unknown) => void) | null,
+  ): void {
+    this._onPropertyMutation = fn
+  }
+
   add(object: BaseObject): this {
     if (object.parent !== null) {
       throw new Error(`Object "${object.id}" already has a parent. Remove it first.`)
     }
     this._objects.push(object)
     this._indexInsert(object)
+    object._setMutationHandler((property, oldValue, newValue) => {
+      this._onPropertyMutation?.(object, property, oldValue, newValue)
+    })
     this._onObjectMutation?.('added', object)
     return this
   }
@@ -74,6 +89,7 @@ export class Layer {
     this._objects.splice(index, 1)
     this._indexRemove(object)
     object.parent = null
+    object._setMutationHandler(null)
     this._onObjectMutation?.('removed', object)
     return this
   }
@@ -81,6 +97,8 @@ export class Layer {
   clear(): this {
     for (const obj of this._objects) {
       this._indexRemove(obj)
+      obj.parent = null
+      obj._setMutationHandler(null)
       obj.destroy()
       this._onObjectMutation?.('removed', obj)
     }
@@ -102,6 +120,7 @@ export class Layer {
     this._objects.splice(index, 1)
     this._indexRemove(object)
     object.parent = null
+    object._setMutationHandler(null)
     this._onObjectMutation?.('removed', object)
     return this
   }

--- a/packages/core/src/Stage.ts
+++ b/packages/core/src/Stage.ts
@@ -141,6 +141,14 @@ export class Stage implements StageInterface {
         { object: obj },
       )
     })
+    layer.setPropertyMutationHandler((obj, property, oldValue, newValue) => {
+      this._events.emitStage('object:mutated', {
+        object: obj,
+        property,
+        oldValue,
+        newValue,
+      })
+    })
     this._layers.push(layer)
     this.markDirty()
     return layer

--- a/packages/core/src/objects/BaseObject.ts
+++ b/packages/core/src/objects/BaseObject.ts
@@ -60,23 +60,68 @@ export abstract class BaseObject {
   private _skewY: number = 0
 
   get x(): number { return this._x }
-  set x(v: number) { this._x = v; this._invalidateBBox() }
+  set x(v: number) {
+    const oldValue = this._x
+    this._x = v
+    if (oldValue !== v) this._mutationHandler?.('x', oldValue, v)
+    this._invalidateBBox()
+  }
   get y(): number { return this._y }
-  set y(v: number) { this._y = v; this._invalidateBBox() }
+  set y(v: number) {
+    const oldValue = this._y
+    this._y = v
+    if (oldValue !== v) this._mutationHandler?.('y', oldValue, v)
+    this._invalidateBBox()
+  }
   get width(): number { return this._width }
-  set width(v: number) { this._width = v; this._invalidateBBox() }
+  set width(v: number) {
+    const oldValue = this._width
+    this._width = v
+    if (oldValue !== v) this._mutationHandler?.('width', oldValue, v)
+    this._invalidateBBox()
+  }
   get height(): number { return this._height }
-  set height(v: number) { this._height = v; this._invalidateBBox() }
+  set height(v: number) {
+    const oldValue = this._height
+    this._height = v
+    if (oldValue !== v) this._mutationHandler?.('height', oldValue, v)
+    this._invalidateBBox()
+  }
   get rotation(): number { return this._rotation }
-  set rotation(v: number) { this._rotation = v; this._invalidateBBox() }
+  set rotation(v: number) {
+    const oldValue = this._rotation
+    this._rotation = v
+    if (oldValue !== v) this._mutationHandler?.('rotation', oldValue, v)
+    this._invalidateBBox()
+  }
   get scaleX(): number { return this._scaleX }
-  set scaleX(v: number) { this._scaleX = v; this._invalidateBBox() }
+  set scaleX(v: number) {
+    const oldValue = this._scaleX
+    this._scaleX = v
+    if (oldValue !== v) this._mutationHandler?.('scaleX', oldValue, v)
+    this._invalidateBBox()
+  }
   get scaleY(): number { return this._scaleY }
-  set scaleY(v: number) { this._scaleY = v; this._invalidateBBox() }
+  set scaleY(v: number) {
+    const oldValue = this._scaleY
+    this._scaleY = v
+    if (oldValue !== v) this._mutationHandler?.('scaleY', oldValue, v)
+    this._invalidateBBox()
+  }
   get skewX(): number { return this._skewX }
-  set skewX(v: number) { this._skewX = v; this._invalidateBBox() }
+  set skewX(v: number) {
+    const oldValue = this._skewX
+    this._skewX = v
+    if (oldValue !== v) this._mutationHandler?.('skewX', oldValue, v)
+    this._invalidateBBox()
+  }
   get skewY(): number { return this._skewY }
-  set skewY(v: number) { this._skewY = v; this._invalidateBBox() }
+  set skewY(v: number) {
+    const oldValue = this._skewY
+    this._skewY = v
+    if (oldValue !== v) this._mutationHandler?.('skewY', oldValue, v)
+    this._invalidateBBox()
+  }
 
   opacity: number
   visible: boolean
@@ -97,6 +142,8 @@ export abstract class BaseObject {
   _worldBBoxCache: BoundingBox | null = null
   /** @internal Set by Layer to receive notifications when this object's bbox changes. */
   private _onBBoxChange: (() => void) | null = null
+  /** @internal Set by Layer to receive notifications when this object's properties change. */
+  private _mutationHandler: ((property: string, oldValue: unknown, newValue: unknown) => void) | null = null
 
   private _eventHandlers = new Map<string, Set<EventHandler<unknown>>>()
 
@@ -210,6 +257,15 @@ export abstract class BaseObject {
    */
   _setBBoxChangeCallback(fn: (() => void) | null): void {
     this._onBBoxChange = fn
+  }
+
+  /**
+   * Register a callback invoked when this object's properties change.
+   * Used internally by Layer to emit object:mutated events on the stage.
+   * @internal
+   */
+  _setMutationHandler(fn: ((property: string, oldValue: unknown, newValue: unknown) => void) | null): void {
+    this._mutationHandler = fn
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,6 +115,17 @@ export interface ObjectEventMap {
   doubletap: CanvasPointerEvent
 }
 
+export interface ObjectMutationEvent {
+  /** The object that changed */
+  object: BaseObject
+  /** The property that changed (e.g. 'x', 'y', 'width', 'rotation', etc.) */
+  property: string
+  /** The previous value before the change */
+  oldValue: unknown
+  /** The new value after the change */
+  newValue: unknown
+}
+
 export interface StageEventMap extends ObjectEventMap {
   wheel: CanvasWheelEvent
   /** Fired after a render frame completes. */
@@ -123,6 +134,8 @@ export interface StageEventMap extends ObjectEventMap {
   'object:added': { object: unknown }
   /** Fired when an object is removed from any layer. */
   'object:removed': { object: unknown }
+  /** Fired when an object's property changes (position, size, rotation, etc.). */
+  'object:mutated': ObjectMutationEvent
   // Plugin events — emitted by official plugins via stage.emit()
   /** Fired by SelectionPlugin when the selection changes. */
   'selection:change': { selected: unknown[] }

--- a/packages/core/tests/object-mutations.test.ts
+++ b/packages/core/tests/object-mutations.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest'
+import { Stage } from '../src/Stage.js'
+import { Rect } from '../src/objects/Rect.js'
+import { Circle } from '../src/objects/Circle.js'
+import { createMockCK, createMockHTMLCanvas } from './__mocks__/canvaskit.js'
+import type { ObjectMutationEvent } from '../src/types.js'
+
+function makeStage() {
+  const ck = createMockCK()
+  const canvas = createMockHTMLCanvas()
+  return { stage: new Stage({ canvas, canvasKit: ck }), ck, canvas }
+}
+
+describe('Object Mutations - NV-029', () => {
+  it('fires object:mutated event when x property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.x = 50
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('x')
+    expect(mutations[0].oldValue).toBe(10)
+    expect(mutations[0].newValue).toBe(50)
+  })
+
+  it('fires object:mutated event when y property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.y = 100
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('y')
+    expect(mutations[0].oldValue).toBe(20)
+    expect(mutations[0].newValue).toBe(100)
+  })
+
+  it('fires object:mutated event when width property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.width = 200
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('width')
+    expect(mutations[0].oldValue).toBe(100)
+    expect(mutations[0].newValue).toBe(200)
+  })
+
+  it('fires object:mutated event when height property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.height = 150
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('height')
+    expect(mutations[0].oldValue).toBe(50)
+    expect(mutations[0].newValue).toBe(150)
+  })
+
+  it('fires object:mutated event when rotation property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50, rotation: 0 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.rotation = 45
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('rotation')
+    expect(mutations[0].oldValue).toBe(0)
+    expect(mutations[0].newValue).toBe(45)
+  })
+
+  it('fires object:mutated event when scaleX property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50, scaleX: 1 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.scaleX = 2
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('scaleX')
+    expect(mutations[0].oldValue).toBe(1)
+    expect(mutations[0].newValue).toBe(2)
+  })
+
+  it('fires object:mutated event when scaleY property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50, scaleY: 1 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.scaleY = 0.5
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('scaleY')
+    expect(mutations[0].oldValue).toBe(1)
+    expect(mutations[0].newValue).toBe(0.5)
+  })
+
+  it('fires object:mutated event when skewX property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50, skewX: 0 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.skewX = 15
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('skewX')
+    expect(mutations[0].oldValue).toBe(0)
+    expect(mutations[0].newValue).toBe(15)
+  })
+
+  it('fires object:mutated event when skewY property changes', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50, skewY: 0 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.skewY = 20
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('skewY')
+    expect(mutations[0].oldValue).toBe(0)
+    expect(mutations[0].newValue).toBe(20)
+  })
+
+  it('does not fire mutations for objects not in a layer', () => {
+    const { stage } = makeStage()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.x = 50
+
+    // Should not fire since object is not in any layer
+    expect(mutations).toHaveLength(0)
+  })
+
+  it('fires multiple mutations when multiple properties change', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.x = 50
+    rect.y = 100
+    rect.width = 200
+
+    expect(mutations).toHaveLength(3)
+    expect(mutations[0].property).toBe('x')
+    expect(mutations[1].property).toBe('y')
+    expect(mutations[2].property).toBe('width')
+  })
+
+  it('fires mutations for different objects independently', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    const circle = new Circle({ x: 30, y: 40, radius: 25 })
+    layer.add(rect)
+    layer.add(circle)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    rect.x = 50
+    circle.y = 100
+
+    expect(mutations).toHaveLength(2)
+    expect(mutations[0].object).toBe(rect)
+    expect(mutations[0].property).toBe('x')
+    expect(mutations[1].object).toBe(circle)
+    expect(mutations[1].property).toBe('y')
+  })
+
+  it('fires mutation once when property is changed multiple times', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    // Change same property multiple times
+    rect.x = 50
+    rect.x = 100
+    rect.x = 150
+
+    // Should fire 3 mutations, one for each assignment
+    expect(mutations).toHaveLength(3)
+    expect(mutations[0].newValue).toBe(50)
+    expect(mutations[1].newValue).toBe(100)
+    expect(mutations[2].newValue).toBe(150)
+  })
+
+  it('does not fire mutation when object is removed from layer', () => {
+    const { stage } = makeStage()
+    const layer = stage.addLayer()
+    const rect = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    layer.add(rect)
+
+    const mutations: ObjectMutationEvent[] = []
+    stage.on('object:mutated', (e) => mutations.push(e))
+
+    layer.remove(rect)
+    rect.x = 50
+
+    // Should not fire since object was removed
+    expect(mutations).toHaveLength(0)
+  })
+
+  it('mutation event can be listened to globally or per-stage', () => {
+    const { stage: stage1 } = makeStage()
+    const { stage: stage2 } = makeStage()
+
+    const layer1 = stage1.addLayer()
+    const layer2 = stage2.addLayer()
+
+    const rect1 = new Rect({ x: 10, y: 20, width: 100, height: 50 })
+    const rect2 = new Rect({ x: 30, y: 40, width: 150, height: 75 })
+
+    layer1.add(rect1)
+    layer2.add(rect2)
+
+    const mutations1: ObjectMutationEvent[] = []
+    const mutations2: ObjectMutationEvent[] = []
+
+    stage1.on('object:mutated', (e) => mutations1.push(e))
+    stage2.on('object:mutated', (e) => mutations2.push(e))
+
+    rect1.x = 50
+    rect2.y = 100
+
+    expect(mutations1).toHaveLength(1)
+    expect(mutations1[0].object).toBe(rect1)
+    expect(mutations2).toHaveLength(1)
+    expect(mutations2[0].object).toBe(rect2)
+  })
+})


### PR DESCRIPTION
Solves #7 

## Problem

NexVas fired no events when an object's position, size, or transform properties changed. There was no `object:moved`, `object:changed`, or `object:mutated` event on the stage.

Any dependent object that needed to react to another object's state change (e.g., a connector tracking a node's port position) had no reactive mechanism. The only option was to use a pre-render pass that ran unconditionally on every dirty frame, regardless of whether anything relevant actually changed.

This led to:
- Inefficient polling in ConnectorPlugin (running endpoint resolution every frame regardless of node movement)
- No clean API for downstream systems to observe mutations
- Architectural coupling between decision-making logic and the render loop

---

## Solution

Implemented a comprehensive mutation event system: **`object:mutated`** event fired on the stage whenever any transform property changes.

### Architecture

The mutation event system uses a **callback chain**:

1. **BaseObject property setters** capture old value, store new value, invoke mutation handler
2. **Layer** wires a handler on each added object that delegates to Stage
3. **Stage** emits the `object:mutated` event on the event bus
4. **Event listeners** (plugins, application code) can subscribe via `stage.on('object:mutated', handler)`

### Key Design Decisions

**1. Efficient: No change, no event**
- Property setters only fire the callback if `oldValue !== newValue`
- Avoids spurious events from code like `obj.x = obj.x` (no-op assignment)

**2. Comprehensive: All transform properties**
- Covered: `x`, `y`, `width`, `height`, `rotation`, `scaleX`, `scaleY`, `skewX`, `skewY`
- These are the properties relevant to spatial position, size, and orientation

**3. Scoped: Only in layers**
- Objects not added to any layer don't fire events
- Objects removed from a layer stop firing events
- Prevents orphaned objects from generating spurious mutation noise

**4. Callback-based, not event-based at the object level**
- Objects don't maintain their own listener sets for mutations
- Avoids object-level listener management complexity
- All mutations funnel through Layer → Stage for centralized handling
- Simpler and more efficient than duplicate event dispatch at object and stage levels

**5. Factory-ready pattern**
- The callback infrastructure is simple and composable
- If future requirements call for per-object mutation listeners, the same pattern can be adapted
- As noted in NV-002 review: "if you implement NV-029 (object:mutated events) and need every settable property on every object to fire events — that's when a factory pays for itself"
- Current implementation avoids premature optimization; adds infrastructure only when needed

---

## Forward Compatibility

### For Plugins and Applications
Subscribe to mutation events:
```ts
stage.on('object:mutated', (e) => {
  console.log(
    `Object ${e.object.id} property "${e.property}" changed from ${e.oldValue} to ${e.newValue}`
  )
})
```

Replace pre-render polling with reactive handlers:
```ts
// OLD: ConnectorPlugin._resolveEndpoints pre-render pass every frame
// NEW: ConnectorPlugin listens to object:mutated for source/target nodes
stage.on('object:mutated', (e) => {
  if (e.property in ['x', 'y', 'width', 'height']) {
    // Check if this is a tracked node
    const connector = findConnectorForNode(e.object.id)
    if (connector) connector.resolveEndpoints()
  }
})
```

### Future Extensibility
If downstream systems need mutations on non-spatial properties (`opacity`, `visible`, `locked`, `fill`, `stroke`, etc.):
1. Add public settings to Layer: `setPropertyMutationHandler` is already there
2. Convert those properties to getter/setter pattern (currently simple fields)
3. Hook into the same callback chain

The current callback architecture supports this without structural changes.

---