### PR TITLE
add stage.registerObject api

### DIFF
--- a/packages/core/src/Layer.ts
+++ b/packages/core/src/Layer.ts
@@ -3,7 +3,7 @@ import type { BaseObject } from './objects/BaseObject.js'
 import { Group } from './objects/Group.js'
 import { objectFromJSON } from './objects/objectFromJSON.js'
 import { BoundingBox } from './math/BoundingBox.js'
-import type { RenderContext, LayerJSON } from './types.js'
+import type { RenderContext, LayerJSON, ObjectDeserializer } from './types.js'
 
 interface RBushItem {
   minX: number
@@ -283,12 +283,18 @@ export class Layer {
 
   /**
    * Restore a layer from its serialized JSON representation.
-   * All built-in object types are supported. Unknown types throw.
+   * All built-in object types are supported. Custom types registered via
+   * {@link Stage.registerObject} are resolved via the optional `registry` argument.
+   *
+   * @param registry - Optional map of custom type names to deserializer functions.
    */
-  static fromJSON(json: LayerJSON): Layer {
+  static fromJSON(
+    json: LayerJSON,
+    registry?: ReadonlyMap<string, ObjectDeserializer>,
+  ): Layer {
     const layer = new Layer({ id: json.id, name: json.name, visible: json.visible, locked: json.locked })
     for (const objJson of json.objects) {
-      layer.add(objectFromJSON(objJson))
+      layer.add(objectFromJSON(objJson, registry))
     }
     return layer
   }

--- a/packages/core/src/Stage.ts
+++ b/packages/core/src/Stage.ts
@@ -12,6 +12,7 @@ import type {
   SceneJSON,
   StageEventMap,
   StageInterface,
+  ObjectDeserializer,
 } from './types.js'
 import type { BaseObject } from './objects/BaseObject.js'
 
@@ -90,6 +91,7 @@ export class Stage implements StageInterface {
   private _surface: SkSurface | null = null
   private _boundContextLost: (e: Event) => void
   private _boundContextRestored: () => void
+  private _objectRegistry = new Map<string, ObjectDeserializer>()
 
   constructor(options: StageOptions) {
     this.id = `stage_${Date.now().toString(36)}`
@@ -369,6 +371,24 @@ export class Stage implements StageInterface {
   // Serialization
   // ---------------------------------------------------------------------------
 
+  /**
+   * Register a custom object type for deserialization.
+   * Once registered, `loadJSON()` will call `deserializer` whenever it encounters
+   * an object whose `type` field equals `typeName`.
+   *
+   * Must be called before `loadJSON()` for the registration to take effect.
+   * Registering the same `typeName` twice replaces the previous deserializer.
+   *
+   * @example
+   * ```ts
+   * stage.registerObject('Node', (json) => NodeObject.fromJSON(json))
+   * stage.loadJSON(savedScene)
+   * ```
+   */
+  registerObject(typeName: string, deserializer: ObjectDeserializer): void {
+    this._objectRegistry.set(typeName, deserializer)
+  }
+
   toJSON(): SceneJSON {
     return {
       version: '1.0.0',
@@ -393,7 +413,7 @@ export class Stage implements StageInterface {
       this.removeLayer(layer)
     }
     for (const layerJson of json.layers) {
-      const layer = Layer.fromJSON(layerJson)
+      const layer = Layer.fromJSON(layerJson, this._objectRegistry)
       this._layers.push(layer)
     }
     this.markDirty()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export type {
   SceneJSON,
   LayerJSON,
   ObjectJSON,
+  ObjectDeserializer,
   ViewportState,
   StageInterface,
   StageEventMap,

--- a/packages/core/src/objects/Group.ts
+++ b/packages/core/src/objects/Group.ts
@@ -1,7 +1,7 @@
 import { BaseObject, type BaseObjectProps } from './BaseObject.js'
 import { BoundingBox } from '../math/BoundingBox.js'
 import { objectFromJSON } from './objectFromJSON.js'
-import type { RenderContext, ObjectJSON, ObjectEventMap } from '../types.js'
+import type { RenderContext, ObjectJSON, ObjectEventMap, ObjectDeserializer } from '../types.js'
 
 interface SkCanvas {
   save(): number
@@ -216,13 +216,16 @@ export class Group extends BaseObject {
     }
   }
 
-  static fromJSON(json: ObjectJSON): Group {
+  static fromJSON(
+    json: ObjectJSON,
+    registry?: ReadonlyMap<string, ObjectDeserializer>,
+  ): Group {
     const obj = new Group({ clip: json['clip'] === true })
     obj.applyBaseJSON(json)
     const children = json['children']
     if (Array.isArray(children)) {
       for (const childJson of children as ObjectJSON[]) {
-        obj.add(objectFromJSON(childJson))
+        obj.add(objectFromJSON(childJson, registry))
       }
     }
     return obj

--- a/packages/core/src/objects/objectFromJSON.ts
+++ b/packages/core/src/objects/objectFromJSON.ts
@@ -1,4 +1,4 @@
-import type { ObjectJSON } from '../types.js'
+import type { ObjectJSON, ObjectDeserializer } from '../types.js'
 import type { BaseObject } from './BaseObject.js'
 import { Rect } from './Rect.js'
 import { Circle } from './Circle.js'
@@ -10,12 +10,19 @@ import { Group } from './Group.js'
 
 /**
  * Deserialize a plain JSON object (from `toJSON()`) back into a typed scene object.
- * Supports all built-in object types. Custom types registered via plugins are not
- * handled here — use a plugin-provided registry for those.
+ * Supports all built-in object types. Custom types registered via
+ * {@link Stage.registerObject} are consulted after the built-in switch falls through.
  *
- * @throws If the `type` field is missing or unrecognized.
+ * @param json - The serialized object data.
+ * @param registry - Optional map of custom type names to deserializer functions,
+ *   provided by {@link Stage} when called from `loadJSON()`.
+ * @throws If the `type` field is missing or unrecognized by both the built-in
+ *   switch and the custom registry.
  */
-export function objectFromJSON(json: ObjectJSON): BaseObject {
+export function objectFromJSON(
+  json: ObjectJSON,
+  registry?: ReadonlyMap<string, ObjectDeserializer>,
+): BaseObject {
   switch (json.type) {
     case 'Rect':
       return Rect.fromJSON(json)
@@ -30,8 +37,11 @@ export function objectFromJSON(json: ObjectJSON): BaseObject {
     case 'CanvasImage':
       return CanvasImage.fromJSON(json)
     case 'Group':
-      return Group.fromJSON(json)
-    default:
+      return Group.fromJSON(json, registry)
+    default: {
+      const deserializer = registry?.get(json.type)
+      if (deserializer !== undefined) return deserializer(json)
       throw new Error(`[nexvas] objectFromJSON: unknown object type "${String(json.type)}"`)
+    }
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,12 @@ import type { Viewport } from './Viewport.js'
 import type { FontManager } from './FontManager.js'
 import type { BaseObject } from './objects/BaseObject.js'
 
+/**
+ * A function that deserializes a plain JSON object into a typed scene object.
+ * Passed to {@link StageInterface.registerObject} to support custom object types in `loadJSON()`.
+ */
+export type ObjectDeserializer = (json: ObjectJSON) => BaseObject
+
 // ---------------------------------------------------------------------------
 // Serialization
 // ---------------------------------------------------------------------------
@@ -228,6 +234,18 @@ export interface StageInterface {
   find(predicate: (obj: BaseObject) => boolean): BaseObject[]
   /** Find all objects of a specific type string (e.g. "Rect", "Circle"). */
   findByType(type: string): BaseObject[]
+  /**
+   * Register a custom object type for deserialization.
+   * Once registered, `loadJSON()` will use the provided deserializer whenever
+   * it encounters an object whose `type` field matches `typeName`.
+   *
+   * @example
+   * ```ts
+   * stage.registerObject('Node', (json) => NodeObject.fromJSON(json))
+   * stage.loadJSON(savedScene)
+   * ```
+   */
+  registerObject(typeName: string, deserializer: ObjectDeserializer): void
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/Stage.test.ts
+++ b/packages/core/tests/Stage.test.ts
@@ -3,7 +3,45 @@ import { Stage } from '../src/Stage.js'
 import { Rect } from '../src/objects/Rect.js'
 import { Circle } from '../src/objects/Circle.js'
 import { Group } from '../src/objects/Group.js'
+import { BaseObject } from '../src/objects/BaseObject.js'
+import { BoundingBox } from '../src/math/BoundingBox.js'
 import { createMockCK, createMockHTMLCanvas } from './__mocks__/canvaskit.js'
+import type { ObjectJSON, RenderContext } from '../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Minimal custom object type used by NV-004 tests
+// ---------------------------------------------------------------------------
+
+class CustomNode extends BaseObject {
+  customProp: string
+
+  constructor(props: { customProp?: string } = {}) {
+    super()
+    this.customProp = props.customProp ?? ''
+  }
+
+  getType(): string {
+    return 'CustomNode'
+  }
+
+  getLocalBoundingBox(): BoundingBox {
+    return new BoundingBox(0, 0, this.width, this.height)
+  }
+
+  render(_ctx: RenderContext): void {
+    // no-op in tests
+  }
+
+  toJSON(): ObjectJSON {
+    return { ...super.toJSON(), customProp: this.customProp }
+  }
+
+  static fromJSON(json: ObjectJSON): CustomNode {
+    const node = new CustomNode({ customProp: json['customProp'] as string | undefined })
+    node.applyBaseJSON(json)
+    return node
+  }
+}
 
 function makeStage() {
   const ck = createMockCK()
@@ -224,6 +262,97 @@ describe('Stage', () => {
       const { stage } = makeStage()
       stage.addLayer()
       expect(stage.find(() => false)).toHaveLength(0)
+    })
+  })
+
+  describe('NV-004 registerObject() — custom type deserialization', () => {
+    it('registerObject allows loadJSON to restore custom types', () => {
+      const { stage } = makeStage()
+      stage.registerObject('CustomNode', CustomNode.fromJSON)
+
+      const layer = stage.addLayer({ name: 'Main' })
+      const node = new CustomNode({ customProp: 'hello' })
+      layer.add(node)
+      const json = stage.toJSON()
+
+      const { stage: stage2 } = makeStage()
+      stage2.registerObject('CustomNode', CustomNode.fromJSON)
+      stage2.loadJSON(json)
+
+      const objs = stage2.layers[0]!.objects
+      expect(objs).toHaveLength(1)
+      expect(objs[0]!.getType()).toBe('CustomNode')
+      expect((objs[0] as CustomNode).customProp).toBe('hello')
+    })
+
+    it('loadJSON throws on unknown type when no deserializer is registered', () => {
+      const { stage } = makeStage()
+      const layer = stage.addLayer()
+      layer.add(new CustomNode())
+      const json = stage.toJSON()
+
+      const { stage: stage2 } = makeStage()
+      // No registerObject call — should throw
+      expect(() => stage2.loadJSON(json)).toThrow(/unknown object type "CustomNode"/)
+    })
+
+    it('registerObject overwrites a previous deserializer for the same type', () => {
+      const { stage } = makeStage()
+      const first = vi.fn().mockImplementation(CustomNode.fromJSON)
+      const second = vi.fn().mockImplementation(CustomNode.fromJSON)
+
+      stage.registerObject('CustomNode', first)
+      stage.registerObject('CustomNode', second)
+
+      const layer = stage.addLayer()
+      layer.add(new CustomNode())
+      const json = stage.toJSON()
+
+      stage.loadJSON(json)
+      expect(second).toHaveBeenCalledOnce()
+      expect(first).not.toHaveBeenCalled()
+    })
+
+    it('custom types inside a Group are deserialized correctly', () => {
+      const { stage } = makeStage()
+      stage.registerObject('CustomNode', CustomNode.fromJSON)
+
+      const layer = stage.addLayer()
+      const group = new Group({ x: 0, y: 0, width: 200, height: 200 })
+      group.add(new CustomNode({ customProp: 'nested' }))
+      layer.add(group)
+      const json = stage.toJSON()
+
+      const { stage: stage2 } = makeStage()
+      stage2.registerObject('CustomNode', CustomNode.fromJSON)
+      stage2.loadJSON(json)
+
+      const restoredGroup = stage2.layers[0]!.objects[0] as Group
+      expect(restoredGroup.getType()).toBe('Group')
+      expect(restoredGroup.children).toHaveLength(1)
+      expect(restoredGroup.children[0]!.getType()).toBe('CustomNode')
+      expect((restoredGroup.children[0] as CustomNode).customProp).toBe('nested')
+    })
+
+    it('mixed built-in and custom types in one layer all round-trip correctly', () => {
+      const { stage } = makeStage()
+      stage.registerObject('CustomNode', CustomNode.fromJSON)
+
+      const layer = stage.addLayer()
+      layer.add(new Rect({ x: 0, y: 0, width: 50, height: 50, name: 'r' }))
+      layer.add(new CustomNode({ customProp: 'c' }))
+      const json = stage.toJSON()
+
+      const { stage: stage2 } = makeStage()
+      stage2.registerObject('CustomNode', CustomNode.fromJSON)
+      stage2.loadJSON(json)
+
+      const objs = stage2.layers[0]!.objects
+      expect(objs).toHaveLength(2)
+      expect(objs[0]!.getType()).toBe('Rect')
+      expect(objs[0]!.name).toBe('r')
+      expect(objs[1]!.getType()).toBe('CustomNode')
+      expect((objs[1] as CustomNode).customProp).toBe('c')
     })
   })
 


### PR DESCRIPTION
Solves #9 
### Overview

Adds `stage.registerObject(typeName, deserializer)` so custom object types can participate in `stage.loadJSON()`. Previously, `objectFromJSON` was a closed switch over built-in types — any custom type caused an "unknown object type" throw. This PR opens that switch by threading a per-stage registry through the full deserialization call chain.