### PR TITLE
Cache getLocalTransform and fix CanvasKit unknown typing

### DIFF
--- a/packages/core/src/Stage.ts
+++ b/packages/core/src/Stage.ts
@@ -6,6 +6,7 @@ import { FontManager } from './FontManager.js'
 import { BoundingBox } from './math/BoundingBox.js'
 import type { ViewportOptions } from './Viewport.js'
 import type {
+  CanvasKitLike,
   Plugin,
   RenderContext,
   RenderPass,
@@ -52,7 +53,7 @@ export interface StageOptions {
   /**
    * CanvasKit instance — result of `loadCanvasKit()` from @nexvas/renderer.
    */
-  canvasKit: unknown
+  canvasKit: CanvasKitLike
   viewport?: ViewportOptions
   /**
    * Device pixel ratio. Defaults to window.devicePixelRatio.
@@ -76,7 +77,7 @@ export interface StageOptions {
 export class Stage implements StageInterface {
   readonly id: string
   readonly canvas: HTMLCanvasElement
-  readonly canvasKit: unknown
+  readonly canvasKit: CanvasKitLike
   readonly viewport: Viewport
   readonly plugins: PluginRegistry
   readonly fonts: FontManager

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export { Vec2, Matrix3x3, BoundingBox } from './math/index.js'
 
 // Types
 export type {
+  CanvasKitLike,
   Plugin,
   RenderContext,
   RenderPass,

--- a/packages/core/src/objects/BaseObject.ts
+++ b/packages/core/src/objects/BaseObject.ts
@@ -64,6 +64,7 @@ export abstract class BaseObject {
     const oldValue = this._x
     this._x = v
     if (oldValue !== v) this._mutationHandler?.('x', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
   get y(): number { return this._y }
@@ -71,6 +72,7 @@ export abstract class BaseObject {
     const oldValue = this._y
     this._y = v
     if (oldValue !== v) this._mutationHandler?.('y', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
   get width(): number { return this._width }
@@ -92,6 +94,7 @@ export abstract class BaseObject {
     const oldValue = this._rotation
     this._rotation = v
     if (oldValue !== v) this._mutationHandler?.('rotation', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
   get scaleX(): number { return this._scaleX }
@@ -99,6 +102,7 @@ export abstract class BaseObject {
     const oldValue = this._scaleX
     this._scaleX = v
     if (oldValue !== v) this._mutationHandler?.('scaleX', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
   get scaleY(): number { return this._scaleY }
@@ -106,6 +110,7 @@ export abstract class BaseObject {
     const oldValue = this._scaleY
     this._scaleY = v
     if (oldValue !== v) this._mutationHandler?.('scaleY', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
   get skewX(): number { return this._skewX }
@@ -113,6 +118,7 @@ export abstract class BaseObject {
     const oldValue = this._skewX
     this._skewX = v
     if (oldValue !== v) this._mutationHandler?.('skewX', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
   get skewY(): number { return this._skewY }
@@ -120,6 +126,7 @@ export abstract class BaseObject {
     const oldValue = this._skewY
     this._skewY = v
     if (oldValue !== v) this._mutationHandler?.('skewY', oldValue, v)
+    this._localTransformCache = null
     this._invalidateBBox()
   }
 
@@ -138,6 +145,8 @@ export abstract class BaseObject {
   /** Reference to the parent Group, set by Group.add(). */
   parent: BaseObject | null = null
 
+  /** @internal Cached local transform matrix. Cleared on any spatial mutation. */
+  _localTransformCache: Matrix3x3 | null = null
   /** @internal Cached world-space AABB. Cleared on any spatial mutation. */
   _worldBBoxCache: BoundingBox | null = null
   /** @internal Set by Layer to receive notifications when this object's bbox changes. */
@@ -180,10 +189,12 @@ export abstract class BaseObject {
    * Computed from this object's own properties only.
    */
   getLocalTransform(): Matrix3x3 {
+    if (this._localTransformCache !== null) return this._localTransformCache
     const rotRad = (this.rotation * Math.PI) / 180
-    return Matrix3x3.translation(this.x, this.y)
+    this._localTransformCache = Matrix3x3.translation(this.x, this.y)
       .multiply(Matrix3x3.rotation(rotRad))
       .multiply(Matrix3x3.scale(this.scaleX, this.scaleY))
+    return this._localTransformCache
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,6 +11,42 @@ import type { BaseObject } from './objects/BaseObject.js'
 export type ObjectDeserializer = (json: ObjectJSON) => BaseObject
 
 // ---------------------------------------------------------------------------
+// Minimal CanvasKit typing (NV-015)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface covering the CanvasKit surface used by core and official
+ * plugins.  Avoids forcing every consumer to cast from `unknown`.
+ *
+ * The index signature allows access to any deeper API without additional casts,
+ * so plugins that use niche CanvasKit features can still call them directly.
+ */
+export interface CanvasKitLike {
+  // Construction
+  Paint: new () => { setColor(c: Float32Array): void; setStyle(s: unknown): void; setStrokeWidth(w: number): void; setAntiAlias(aa: boolean): void; delete(): void; [k: string]: unknown }
+  Color4f(r: number, g: number, b: number, a: number): Float32Array
+  LTRBRect(l: number, t: number, r: number, b: number): Float32Array
+
+  // Enums
+  PaintStyle: { Fill: unknown; Stroke: unknown }
+  StrokeCap?: { Butt: unknown; Round: unknown; Square: unknown }
+  StrokeJoin?: { Miter: unknown; Round: unknown; Bevel: unknown }
+  TileMode?: { Clamp: unknown; [k: string]: unknown }
+  ColorSpace?: { SRGB: unknown; [k: string]: unknown }
+
+  // Factories
+  Shader?: { MakeLinearGradient(start: number[], end: number[], colors: Float32Array[], positions: number[] | null, mode: unknown): unknown }
+  PathEffect?: { MakeDash(intervals: number[], phase?: number): unknown; [k: string]: unknown }
+
+  // Surface / canvas
+  MakeWebGLCanvasSurface?(canvas: HTMLCanvasElement, colorSpace?: unknown, opts?: unknown): unknown
+  MakeImageFromEncoded?(data: Uint8Array): unknown
+
+  // Allow arbitrary access for niche or newer APIs
+  [key: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
 // Serialization
 // ---------------------------------------------------------------------------
 
@@ -61,7 +97,7 @@ export interface RenderContext {
   /** CanvasKit SkCanvas instance — cast to SkCanvas inside render() implementations. */
   skCanvas: unknown
   /** CanvasKit instance — used to create Paints, Paths, etc. inside render(). */
-  canvasKit: unknown
+  canvasKit: CanvasKitLike
   /** FontManager for loading and retrieving typefaces for Text rendering. */
   fontManager: FontManager | null
   /** Device pixel ratio for HiDPI rendering. */
@@ -215,7 +251,7 @@ export interface StrokeStyle {
 /** Minimal interface that plugins interact with. Full Stage extends this. */
 export interface StageInterface {
   readonly id: string
-  readonly canvasKit: unknown
+  readonly canvasKit: CanvasKitLike
   readonly layers: readonly Layer[]
   readonly viewport: Viewport
   readonly fonts: FontManager

--- a/packages/core/tests/error-prefixes.test.ts
+++ b/packages/core/tests/error-prefixes.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ---------------------------------------------------------------------------
+// NV-023 — Verify all error/warning prefixes follow [nexvas:<module>] format
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const CORE_SRC = resolve(__dirname, '../src')
+
+/** Recursively collect all .ts files under a directory. */
+function collectTsFiles(dir: string): string[] {
+  const results: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      results.push(...collectTsFiles(full))
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+      results.push(full)
+    }
+  }
+  return results
+}
+
+describe('NV-023: error prefix consistency', () => {
+  const files = collectTsFiles(CORE_SRC)
+
+  it('all [nexvas] prefixes use the [nexvas:<module>] format', () => {
+    const violations: string[] = []
+
+    // Matches [nexvas] NOT followed by a colon — i.e. bare [nexvas] prefixes
+    // Allowed: [nexvas:stage], [nexvas:image], etc.
+    // Forbidden: [nexvas] Stage.resize(), [nexvas] FontManager:, etc.
+    const bare = /\[nexvas\](?!:)/g
+
+    for (const file of files) {
+      const content = readFileSync(file, 'utf-8')
+      const lines = content.split('\n')
+      for (let i = 0; i < lines.length; i++) {
+        if (bare.test(lines[i]!)) {
+          const rel = file.replace(CORE_SRC, 'src')
+          violations.push(`${rel}:${i + 1}: ${lines[i]!.trim()}`)
+        }
+        bare.lastIndex = 0 // reset regex state
+      }
+    }
+
+    expect(violations, `Bare [nexvas] prefixes found:\n${violations.join('\n')}`).toHaveLength(0)
+  })
+})

--- a/packages/core/tests/objects/BaseObject-transform-cache.test.ts
+++ b/packages/core/tests/objects/BaseObject-transform-cache.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { Rect } from '../../src/objects/Rect.js'
+
+describe('BaseObject — getLocalTransform() caching (NV-021)', () => {
+  it('returns the same reference on consecutive calls', () => {
+    const r = new Rect({ x: 10, y: 20, width: 100, height: 50, rotation: 45 })
+    const m1 = r.getLocalTransform()
+    const m2 = r.getLocalTransform()
+    expect(m1).toBe(m2) // same instance, not just equal values
+  })
+
+  it('invalidates cache when x changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.x = 5
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+    expect(after.values[2]).toBe(5) // tx
+  })
+
+  it('invalidates cache when y changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.y = 7
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+    expect(after.values[5]).toBe(7) // ty
+  })
+
+  it('invalidates cache when rotation changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.rotation = 90
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+  })
+
+  it('invalidates cache when scaleX changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.scaleX = 2
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+    // For identity rotation, scale matrix a = scaleX
+    expect(after.values[0]).toBe(2)
+  })
+
+  it('invalidates cache when scaleY changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.scaleY = 3
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+    expect(after.values[4]).toBe(3)
+  })
+
+  it('invalidates cache when skewX changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.skewX = 0.5
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+  })
+
+  it('invalidates cache when skewY changes', () => {
+    const r = new Rect({ x: 0, y: 0, width: 10, height: 10 })
+    const before = r.getLocalTransform()
+    r.skewY = 0.5
+    const after = r.getLocalTransform()
+    expect(after).not.toBe(before)
+  })
+
+  it('returns correct matrix values after invalidation', () => {
+    const r = new Rect({ x: 10, y: 20, width: 50, height: 50, scaleX: 2, scaleY: 3 })
+    const m1 = r.getLocalTransform()
+    expect(m1.values[2]).toBe(10) // tx
+    expect(m1.values[5]).toBe(20) // ty
+    expect(m1.values[0]).toBe(2)  // scaleX (no rotation)
+    expect(m1.values[4]).toBe(3)  // scaleY (no rotation)
+
+    r.x = 50
+    r.scaleX = 4
+    const m2 = r.getLocalTransform()
+    expect(m2.values[2]).toBe(50) // updated tx
+    expect(m2.values[0]).toBe(4)  // updated scaleX
+    expect(m2.values[5]).toBe(20) // ty unchanged
+    expect(m2.values[4]).toBe(3)  // scaleY unchanged
+  })
+})


### PR DESCRIPTION
## Issues Closed

Title | Resolution |
|---|---|
| NV-021 | `getLocalTransform()` not cached | **Fixed** — cached with per-property invalidation |
| NV-015 | Plugin CanvasKit typing (`canvasKit: unknown`) | **Fixed** — new `CanvasKitLike` interface replaces `unknown` |

## Changes

###  Cache `getLocalTransform()`

`BaseObject.getLocalTransform()` was creating 3 `Matrix3x3` objects (translation, rotation, scale) and multiplying them on every call. It is called 3+ times per object per frame (render + cull + hit test), so this was a significant allocation hotspot.

**Before:** Every call computes and returns a new matrix.

**After:** Result is cached in `_localTransformCache`. Subsequent calls return the same instance until a spatial property changes.

Cache is invalidated (set to `null`) in the setters for all 7 spatial properties:
- `x`, `y` - translation
- `rotation` - rotation angle
- `scaleX`, `scaleY` - scale factors
- `skewX`, `skewY` - skew (invalidation added for completeness, though skew is not yet used in the matrix computation)

This mirrors the existing `_worldBBoxCache` pattern already used by `getWorldBoundingBox()`.

### Plugin CanvasKit Typing

`StageInterface.canvasKit`, `RenderContext.canvasKit`, `StageOptions.canvasKit`, and `Stage.canvasKit` were all typed as `unknown`, forcing every plugin and object renderer to define its own local CanvasKit interface and cast.

**Before:** `canvasKit: unknown` - plugins must cast on every access.

**After:** `canvasKit: CanvasKitLike` - a minimal interface covering the common API surface used by core and all official plugins.

The `CanvasKitLike` interface includes:
- **Required:** `Paint` (constructor), `Color4f`, `LTRBRect`, `PaintStyle`
- **Optional:** `StrokeCap`, `StrokeJoin`, `TileMode`, `ColorSpace`, `Shader`, `PathEffect`, `MakeWebGLCanvasSurface`, `MakeImageFromEncoded`
- **Index signature:** `[key: string]: unknown` - allows access to any deeper CanvasKit API without additional casts

The required/optional split was determined by auditing actual usage across: `packages/core/src/renderer/paint.ts`, `packages/core/src/Stage.ts`, all object renderers (Rect, Circle, Path, Line, Text, CanvasImage, Group), and all plugins (selection, grid, guides, export).