### PR TITLE
Implement connector + routing algorithm

### DIFF
--- a/packages/core/src/Stage.ts
+++ b/packages/core/src/Stage.ts
@@ -533,6 +533,7 @@ export class Stage implements StageInterface {
       fontManager: this.fonts,
       pixelRatio: this._pixelRatio,
       viewport: vp,
+      stage: this,
     }
 
     // Pre-render passes (e.g. grid background)

--- a/packages/core/src/objects/Connector.ts
+++ b/packages/core/src/objects/Connector.ts
@@ -1,0 +1,552 @@
+import { BaseObject, type BaseObjectProps } from './BaseObject.js'
+import { BoundingBox } from '../math/BoundingBox.js'
+import {
+  makeStrokePaint,
+  strokeCacheKey,
+  drawArrowHead,
+  makeEffectPaint,
+  effectsCacheKey,
+  colorToCK,
+  type PaintCK,
+  type ArrowCK,
+  type EffectCK,
+  type SkPaint,
+} from '../renderer/paint.js'
+import type { RenderContext, ObjectJSON, StageInterface, StrokeStyle } from '../types.js'
+import type { ConnectorRouting, Route, RoutePoint } from './routing/types.js'
+import { routeStraight } from './routing/straight.js'
+import { routeOrthogonal } from './routing/orthogonal.js'
+import { routeCurved, sampleBezier } from './routing/curved.js'
+
+// ---------------------------------------------------------------------------
+// CanvasKit interface stubs
+// ---------------------------------------------------------------------------
+
+interface SkPath {
+  moveTo(x: number, y: number): void
+  lineTo(x: number, y: number): void
+  cubicTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void
+  delete(): void
+}
+
+interface SkCanvas {
+  save(): number
+  restore(): void
+  saveLayer(paint: unknown): number
+  drawPath(path: unknown, paint: unknown): void
+  translate(dx: number, dy: number): void
+  drawParagraph(para: unknown, x: number, y: number): void
+}
+
+interface SkParagraph {
+  layout(width: number): void
+  getHeight(): number
+  delete(): void
+}
+
+interface SkParagraphBuilder {
+  pushStyle(style: unknown): void
+  addText(text: string): void
+  build(): SkParagraph
+  delete(): void
+}
+
+interface LabelCK extends PaintCK {
+  ParagraphStyle(opts: { textAlign?: unknown; textStyle?: unknown }): unknown
+  ParagraphBuilder: {
+    MakeFromFontProvider(style: unknown, fontProvider: unknown): SkParagraphBuilder
+  }
+  TextAlign: { Center: unknown }
+  FontWeight: { Normal: unknown }
+  FontWidth: { Normal: unknown }
+  FontSlant: { Upright: unknown }
+  TextBaseline: { Alphabetic: unknown }
+  DecorationStyle: { Solid: unknown }
+}
+
+interface ConnectorCK extends PaintCK {
+  Path: new () => SkPath
+}
+
+// ---------------------------------------------------------------------------
+// Connector endpoint types
+// ---------------------------------------------------------------------------
+
+/** A fixed world-space point. */
+export interface ConnectorEndpointFixed {
+  x: number
+  y: number
+}
+
+/** A reference to a named port on another object. */
+export interface ConnectorEndpointRef {
+  objectId: string
+  portId: string
+}
+
+export type ConnectorEndpoint = ConnectorEndpointFixed | ConnectorEndpointRef
+
+function isRef(ep: ConnectorEndpoint): ep is ConnectorEndpointRef {
+  return 'objectId' in ep
+}
+
+// ---------------------------------------------------------------------------
+// ConnectorProps
+// ---------------------------------------------------------------------------
+
+export interface ConnectorProps extends BaseObjectProps {
+  /** Source endpoint — fixed world point or object port reference. */
+  source: ConnectorEndpoint
+  /** Target endpoint — fixed world point or object port reference. */
+  target: ConnectorEndpoint
+  /** Routing algorithm. Defaults to 'straight'. */
+  routing?: ConnectorRouting
+  /** Optional label rendered at the path midpoint. */
+  label?: string
+  /** Label position along the path, 0–1. Defaults to 0.5. */
+  labelOffset?: number
+  /** User-defined intermediate waypoints (world space). */
+  waypoints?: RoutePoint[]
+}
+
+// ---------------------------------------------------------------------------
+// Serialization type
+// ---------------------------------------------------------------------------
+
+export interface ConnectorJSON extends ObjectJSON {
+  sourceRef: ConnectorEndpoint
+  targetRef: ConnectorEndpoint
+  routing: ConnectorRouting
+  label: string
+  labelOffset: number
+  waypoints: RoutePoint[]
+}
+
+// ---------------------------------------------------------------------------
+// Default stroke for connectors
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONNECTOR_STROKE: StrokeStyle = {
+  color: { r: 0.2, g: 0.2, b: 0.2, a: 1 },
+  width: 2,
+  endArrow: 'filled-arrow',
+}
+
+// ---------------------------------------------------------------------------
+// Distance helpers
+// ---------------------------------------------------------------------------
+
+function distToSegment(px: number, py: number, a: RoutePoint, b: RoutePoint): number {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  const lenSq = dx * dx + dy * dy
+  if (lenSq === 0) return Math.hypot(px - a.x, py - a.y)
+  const t = Math.max(0, Math.min(1, ((px - a.x) * dx + (py - a.y) * dy) / lenSq))
+  return Math.hypot(px - (a.x + t * dx), py - (a.y + t * dy))
+}
+
+// ---------------------------------------------------------------------------
+// Connector
+// ---------------------------------------------------------------------------
+
+/**
+ * A smart line between two endpoints (fixed world points or object ports).
+ * Supports straight, orthogonal (right-angle), and curved (cubic bezier) routing.
+ * Resolves attached object port positions at render time via the stage reference
+ * in RenderContext — survives JSON round-trips because only ids are stored.
+ */
+export class Connector extends BaseObject {
+  /** Source endpoint — fixed point or port reference. */
+  source: ConnectorEndpoint
+  /** Target endpoint — fixed point or port reference. */
+  target: ConnectorEndpoint
+  /** Routing algorithm used to draw the path. */
+  routing: ConnectorRouting
+  /** Optional label string rendered at the midpoint of the path. */
+  label: string
+  /** Position of the label along the path (0 = source, 1 = target). */
+  labelOffset: number
+  /** User-defined intermediate waypoints in world space. */
+  waypoints: RoutePoint[]
+
+  // ---------------------------------------------------------------------------
+  // Internal cache — populated during render(), used for hit testing and bbox
+  // ---------------------------------------------------------------------------
+
+  private _cachedRoute: Route | null = null
+  private _cachedSrc: RoutePoint | null = null
+  private _cachedTgt: RoutePoint | null = null
+  private _pathCache: { path: SkPath; key: string } | null = null
+  private _labelParagraph: SkParagraph | null = null
+  private _labelKey = ''
+
+  constructor(props: ConnectorProps) {
+    super(props)
+    this.source = props.source
+    this.target = props.target
+    this.routing = props.routing ?? 'straight'
+    this.label = props.label ?? ''
+    this.labelOffset = props.labelOffset ?? 0.5
+    this.waypoints = props.waypoints ?? []
+    // Connector has no meaningful local transform — it draws in world space.
+    // Force identity so getWorldBoundingBox() == getLocalBoundingBox().
+    this.x = 0
+    this.y = 0
+  }
+
+  getType(): string {
+    return 'Connector'
+  }
+
+  // ---------------------------------------------------------------------------
+  // Endpoint resolution
+  // ---------------------------------------------------------------------------
+
+  private _resolveEndpoint(ep: ConnectorEndpoint, stage: StageInterface): RoutePoint | null {
+    if (isRef(ep)) {
+      const obj = stage.getObjectById(ep.objectId)
+      if (!obj) return null
+      return obj.getPortWorldPosition(ep.portId)
+    }
+    return { x: ep.x, y: ep.y }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Route building
+  // ---------------------------------------------------------------------------
+
+  private _buildRoute(sx: number, sy: number, tx: number, ty: number): Route {
+    switch (this.routing) {
+      case 'orthogonal':
+        return routeOrthogonal(sx, sy, tx, ty, this.waypoints)
+      case 'curved':
+        return routeCurved(sx, sy, tx, ty, this.waypoints)
+      default:
+        return routeStraight(sx, sy, tx, ty, this.waypoints)
+    }
+  }
+
+  private _pathKey(src: RoutePoint, tgt: RoutePoint): string {
+    let key = `${src.x},${src.y},${tgt.x},${tgt.y},${this.routing}`
+    for (const wp of this.waypoints) key += `,${wp.x},${wp.y}`
+    return key
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bounding box — based on cached route points
+  // ---------------------------------------------------------------------------
+
+  getLocalBoundingBox(): BoundingBox {
+    const pts = this._aabbPoints()
+    if (pts.length === 0) {
+      // Fall back to fixed endpoint coords if not yet rendered
+      const sx = isRef(this.source) ? 0 : this.source.x
+      const sy = isRef(this.source) ? 0 : this.source.y
+      const tx = isRef(this.target) ? sx : this.target.x
+      const ty = isRef(this.target) ? sy : this.target.y
+      const minX = Math.min(sx, tx)
+      const minY = Math.min(sy, ty)
+      return new BoundingBox(minX, minY, Math.max(Math.abs(tx - sx), 1), Math.max(Math.abs(ty - sy), 1))
+    }
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const p of pts) {
+      if (p.x < minX) minX = p.x
+      if (p.y < minY) minY = p.y
+      if (p.x > maxX) maxX = p.x
+      if (p.y > maxY) maxY = p.y
+    }
+    const pad = (this.stroke?.width ?? DEFAULT_CONNECTOR_STROKE.width!) / 2 + 8
+    return new BoundingBox(minX - pad, minY - pad, maxX - minX + pad * 2, maxY - minY + pad * 2)
+  }
+
+  private _aabbPoints(): RoutePoint[] {
+    if (!this._cachedRoute) return []
+    const r = this._cachedRoute
+    if (r.kind === 'polyline') return r.points
+    // For bezier: use all control points — the bezier lies within their convex hull
+    const pts: RoutePoint[] = []
+    for (const seg of r.segments) pts.push(seg.p0, seg.p1, seg.p2, seg.p3)
+    return pts
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hit testing
+  // ---------------------------------------------------------------------------
+
+  hitTest(worldX: number, worldY: number, tolerance = 8): boolean {
+    if (!this.visible || !this._cachedRoute) return false
+    const r = this._cachedRoute
+    if (r.kind === 'polyline') {
+      const pts = r.points
+      for (let i = 0; i < pts.length - 1; i++) {
+        if (distToSegment(worldX, worldY, pts[i] as RoutePoint, pts[i + 1] as RoutePoint) <= tolerance) return true
+      }
+      return false
+    }
+    // Cubic bezier: sample each segment at 24 intervals
+    for (const seg of r.segments) {
+      const STEPS = 24
+      let prev = seg.p0
+      for (let i = 1; i <= STEPS; i++) {
+        const cur = sampleBezier(seg, i / STEPS)
+        if (distToSegment(worldX, worldY, prev, cur) <= tolerance) return true
+        prev = cur
+      }
+    }
+    return false
+  }
+
+  // ---------------------------------------------------------------------------
+  // Path midpoint (for label placement and arrowheads)
+  // ---------------------------------------------------------------------------
+
+  private _midpoint(): RoutePoint {
+    if (!this._cachedRoute) return { x: 0, y: 0 }
+    const r = this._cachedRoute
+    if (r.kind === 'polyline') {
+      const pts = r.points
+      // Compute total length and find point at labelOffset fraction
+      let totalLen = 0
+      for (let i = 0; i < pts.length - 1; i++) {
+        const a = pts[i] as RoutePoint, b = pts[i + 1] as RoutePoint
+        totalLen += Math.hypot(b.x - a.x, b.y - a.y)
+      }
+      const target = totalLen * this.labelOffset
+      let acc = 0
+      for (let i = 0; i < pts.length - 1; i++) {
+        const a = pts[i] as RoutePoint, b = pts[i + 1] as RoutePoint
+        const segLen = Math.hypot(b.x - a.x, b.y - a.y)
+        if (acc + segLen >= target) {
+          const t = segLen > 0 ? (target - acc) / segLen : 0
+          return { x: a.x + t * (b.x - a.x), y: a.y + t * (b.y - a.y) }
+        }
+        acc += segLen
+      }
+      return pts[pts.length - 1] as RoutePoint
+    }
+    // Bezier: sample at labelOffset
+    const segs = r.segments
+    const t = this.labelOffset * segs.length
+    const idx = Math.min(Math.floor(t), segs.length - 1)
+    return sampleBezier(segs[idx] as NonNullable<typeof segs[number]>, t - idx)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  render(ctx: RenderContext): void {
+    if (!this.visible || !ctx.skCanvas) return
+
+    const ck = ctx.canvasKit as unknown as ConnectorCK
+    const canvas = ctx.skCanvas as SkCanvas
+    const stage = ctx.stage
+
+    const src = this._resolveEndpoint(this.source, stage)
+    const tgt = this._resolveEndpoint(this.target, stage)
+    if (!src || !tgt) return
+
+    this._cachedSrc = src
+    this._cachedTgt = tgt
+    this._cachedRoute = this._buildRoute(src.x, src.y, tgt.x, tgt.y)
+
+    // Build or reuse cached SkPath
+    const pk = this._pathKey(src, tgt)
+    if (this._pathCache?.key !== pk) {
+      this._pathCache?.path.delete()
+      const skPath = new ck.Path()
+      this._fillSkPath(skPath, this._cachedRoute)
+      this._pathCache = { path: skPath, key: pk }
+    }
+
+    canvas.save()
+    // No local transform — Connector draws in world space (viewport transform is already on canvas)
+
+    const hasEffects = this.effects.length > 0
+    if (hasEffects) {
+      const ek = effectsCacheKey(this.effects)
+      if (this._effectPaintCache?.key !== ek) {
+        ;(this._effectPaintCache?.paint as SkPaint | undefined)?.delete()
+        this._effectPaintCache = { paint: makeEffectPaint(ck as unknown as EffectCK, this.effects), key: ek }
+      }
+      canvas.saveLayer(this._effectPaintCache!.paint)
+    }
+
+    const stroke = this.stroke ?? DEFAULT_CONNECTOR_STROKE
+    const sk = strokeCacheKey(stroke, this.opacity)
+    if (this._strokePaintCache?.key !== sk) {
+      ;(this._strokePaintCache?.paint as SkPaint | undefined)?.delete()
+      this._strokePaintCache = { paint: makeStrokePaint(ck, stroke, this.opacity), key: sk }
+    }
+
+    canvas.drawPath(this._pathCache!.path, this._strokePaintCache!.paint as SkPaint)
+
+    // Arrowheads
+    this._drawArrows(canvas, ck as unknown as ArrowCK, src, tgt, stroke)
+
+    // Label
+    if (this.label) this._drawLabel(canvas, ck as unknown as LabelCK, ctx)
+
+    if (hasEffects) canvas.restore()
+    canvas.restore()
+  }
+
+  private _fillSkPath(path: SkPath, route: Route): void {
+    if (route.kind === 'polyline') {
+      const pts = route.points
+      if (pts.length === 0) return
+      path.moveTo((pts[0] as RoutePoint).x, (pts[0] as RoutePoint).y)
+      for (let i = 1; i < pts.length; i++) path.lineTo((pts[i] as RoutePoint).x, (pts[i] as RoutePoint).y)
+    } else {
+      for (const seg of route.segments) {
+        path.moveTo(seg.p0.x, seg.p0.y)
+        path.cubicTo(seg.p1.x, seg.p1.y, seg.p2.x, seg.p2.y, seg.p3.x, seg.p3.y)
+      }
+    }
+  }
+
+  private _drawArrows(
+    canvas: SkCanvas,
+    ck: ArrowCK,
+    src: RoutePoint,
+    tgt: RoutePoint,
+    stroke: StrokeStyle,
+  ): void {
+    const startArrow = stroke.startArrow ?? 'none'
+    const endArrow = stroke.endArrow ?? 'none'
+    if (startArrow === 'none' && endArrow === 'none') return
+    if (!ck.Path) return
+
+    const arrowSize = (stroke.width ?? 2) * 5
+    const r = this._cachedRoute!
+
+    if (startArrow !== 'none') {
+      let angle: number
+      if (r.kind === 'polyline' && r.points.length >= 2) {
+        const a = r.points[0] as RoutePoint, b = r.points[1] as RoutePoint
+        angle = Math.atan2(a.y - b.y, a.x - b.x)
+      } else if (r.kind === 'cubic-bezier' && r.segments.length > 0) {
+        const seg = r.segments[0]!
+        angle = Math.atan2(seg.p0.y - seg.p1.y, seg.p0.x - seg.p1.x)
+      } else {
+        angle = Math.atan2(src.y - tgt.y, src.x - tgt.x)
+      }
+      drawArrowHead(canvas, ck, src.x, src.y, angle, startArrow, arrowSize, stroke, this.opacity)
+    }
+
+    if (endArrow !== 'none') {
+      let angle: number
+      if (r.kind === 'polyline' && r.points.length >= 2) {
+        const pts = r.points
+        const a = pts[pts.length - 2] as RoutePoint, b = pts[pts.length - 1] as RoutePoint
+        angle = Math.atan2(b.y - a.y, b.x - a.x)
+      } else if (r.kind === 'cubic-bezier' && r.segments.length > 0) {
+        const seg = r.segments[r.segments.length - 1]!
+        angle = Math.atan2(seg.p3.y - seg.p2.y, seg.p3.x - seg.p2.x)
+      } else {
+        angle = Math.atan2(tgt.y - src.y, tgt.x - src.x)
+      }
+      drawArrowHead(canvas, ck, tgt.x, tgt.y, angle, endArrow, arrowSize, stroke, this.opacity)
+    }
+  }
+
+  private _drawLabel(canvas: SkCanvas, ck: LabelCK, ctx: RenderContext): void {
+    const fontMgr = ctx.fontManager
+    if (!fontMgr || !ck.ParagraphBuilder) return
+
+    const fontProvider = fontMgr.getFontProvider()
+    if (!fontProvider) return
+
+    const labelKey = `${this.label},${this.opacity}`
+    if (this._labelKey !== labelKey) {
+      this._labelParagraph?.delete()
+      this._labelParagraph = null
+      this._labelKey = labelKey
+    }
+
+    if (!this._labelParagraph) {
+      const stroke = this.stroke ?? DEFAULT_CONNECTOR_STROKE
+      const col = colorToCK(ck, stroke.color)
+      const textStyle = {
+        color: col,
+        decoration: 0,
+        decorationColor: ck.Color4f(0, 0, 0, 0),
+        decorationThickness: 0,
+        decorationStyle: ck.DecorationStyle.Solid,
+        fontFamilies: ['Noto Sans'],
+        fontSize: 12,
+        fontStyle: {
+          weight: ck.FontWeight.Normal,
+          width: ck.FontWidth.Normal,
+          slant: ck.FontSlant.Upright,
+        },
+        foregroundColor: ck.Color4f(0, 0, 0, 0),
+        backgroundColor: ck.Color4f(0, 0, 0, 0),
+        heightMultiplier: 1.2,
+        halfLeading: false,
+        letterSpacing: 0,
+        locale: '',
+        shadows: [],
+        fontFeatures: [],
+        fontVariations: [],
+        textBaseline: ck.TextBaseline.Alphabetic,
+        wordSpacing: 0,
+      }
+      const paraStyle = ck.ParagraphStyle({ textAlign: ck.TextAlign.Center, textStyle: { color: ck.Color4f(0, 0, 0, 1) } })
+      const builder = ck.ParagraphBuilder.MakeFromFontProvider(paraStyle, fontProvider)
+      builder.pushStyle(textStyle)
+      builder.addText(this.label)
+      this._labelParagraph = builder.build()
+      builder.delete()
+      this._labelParagraph.layout(200)
+    }
+
+    const mid = this._midpoint()
+    canvas.save()
+    canvas.translate(mid.x - 100, mid.y - this._labelParagraph.getHeight() / 2)
+    canvas.drawParagraph(this._labelParagraph, 0, 0)
+    canvas.restore()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Destroy
+  // ---------------------------------------------------------------------------
+
+  destroy(): void {
+    this._pathCache?.path.delete()
+    this._pathCache = null
+    this._labelParagraph?.delete()
+    this._labelParagraph = null
+    super.destroy()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Serialization
+  // ---------------------------------------------------------------------------
+
+  toJSON(): ConnectorJSON {
+    return {
+      ...super.toJSON(),
+      sourceRef: this.source,
+      targetRef: this.target,
+      routing: this.routing,
+      label: this.label,
+      labelOffset: this.labelOffset,
+      waypoints: this.waypoints,
+    }
+  }
+
+  static fromJSON(json: ObjectJSON): Connector {
+    const j = json as ConnectorJSON
+    const obj = new Connector({
+      source: j.sourceRef ?? { x: 0, y: 0 },
+      target: j.targetRef ?? { x: 100, y: 100 },
+      routing: j.routing ?? 'straight',
+      label: j.label ?? '',
+      labelOffset: j.labelOffset ?? 0.5,
+      waypoints: j.waypoints ?? [],
+    })
+    obj.applyBaseJSON(json)
+    return obj
+  }
+}

--- a/packages/core/src/objects/index.ts
+++ b/packages/core/src/objects/index.ts
@@ -6,3 +6,12 @@ export { Text, type TextProps, type TextAlign, type TextBaseline } from './Text.
 export { CanvasImage, type ImageProps } from './CanvasImage.js'
 export { Path, type PathProps } from './Path.js'
 export { Group, type GroupProps } from './Group.js'
+export {
+  Connector,
+  type ConnectorProps,
+  type ConnectorEndpoint,
+  type ConnectorEndpointFixed,
+  type ConnectorEndpointRef,
+  type ConnectorJSON,
+} from './Connector.js'
+export type { ConnectorRouting, RoutePoint } from './routing/types.js'

--- a/packages/core/src/objects/objectFromJSON.ts
+++ b/packages/core/src/objects/objectFromJSON.ts
@@ -7,6 +7,7 @@ import { Path } from './Path.js'
 import { Text } from './Text.js'
 import { CanvasImage } from './CanvasImage.js'
 import { Group } from './Group.js'
+import { Connector } from './Connector.js'
 
 /**
  * Deserialize a plain JSON object (from `toJSON()`) back into a typed scene object.
@@ -38,6 +39,8 @@ export function objectFromJSON(
       return CanvasImage.fromJSON(json)
     case 'Group':
       return Group.fromJSON(json, registry)
+    case 'Connector':
+      return Connector.fromJSON(json)
     default: {
       const deserializer = registry?.get(json.type)
       if (deserializer !== undefined) return deserializer(json)

--- a/packages/core/src/objects/routing/curved.ts
+++ b/packages/core/src/objects/routing/curved.ts
@@ -1,0 +1,45 @@
+import type { RoutePoint, CubicBezierRoute, BezierSegment } from './types.js'
+
+/**
+ * Curved routing — cubic bezier segments with auto-computed control points.
+ * Control points flow horizontally out of/into each endpoint, creating smooth S-curves.
+ * Multiple waypoints create chained bezier segments.
+ */
+export function routeCurved(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  waypoints: RoutePoint[],
+): CubicBezierRoute {
+  const all: RoutePoint[] = [{ x: sx, y: sy }, ...waypoints, { x: tx, y: ty }]
+  const segments: BezierSegment[] = []
+
+  for (let i = 0; i < all.length - 1; i++) {
+    const p0 = all[i] as RoutePoint
+    const p3 = all[i + 1] as RoutePoint
+    const dx = (p3.x - p0.x) * 0.5
+    segments.push({
+      p0,
+      p1: { x: p0.x + dx, y: p0.y },
+      p2: { x: p3.x - dx, y: p3.y },
+      p3,
+    })
+  }
+
+  return { kind: 'cubic-bezier', segments }
+}
+
+/**
+ * Sample a cubic bezier segment at parameter t ∈ [0, 1].
+ * Used by hit testing to approximate distance to the curve.
+ */
+export function sampleBezier(seg: BezierSegment, t: number): RoutePoint {
+  const mt = 1 - t
+  const mt2 = mt * mt
+  const t2 = t * t
+  return {
+    x: mt2 * mt * seg.p0.x + 3 * mt2 * t * seg.p1.x + 3 * mt * t2 * seg.p2.x + t2 * t * seg.p3.x,
+    y: mt2 * mt * seg.p0.y + 3 * mt2 * t * seg.p1.y + 3 * mt * t2 * seg.p2.y + t2 * t * seg.p3.y,
+  }
+}

--- a/packages/core/src/objects/routing/orthogonal.ts
+++ b/packages/core/src/objects/routing/orthogonal.ts
@@ -1,0 +1,41 @@
+import type { RoutePoint, PolylineRoute } from './types.js'
+
+/**
+ * Orthogonal (Manhattan) routing — right-angle segments only.
+ * Without waypoints: routes through a single vertical midpoint column.
+ * With waypoints: routes through each waypoint with a right-angle bend.
+ */
+export function routeOrthogonal(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  waypoints: RoutePoint[],
+): PolylineRoute {
+  if (waypoints.length === 0) {
+    const midX = (sx + tx) / 2
+    return {
+      kind: 'polyline',
+      points: [
+        { x: sx, y: sy },
+        { x: midX, y: sy },
+        { x: midX, y: ty },
+        { x: tx, y: ty },
+      ],
+    }
+  }
+
+  // Route through each waypoint with right-angle bends:
+  // from previous point, go horizontal to waypoint x, then vertical to waypoint y.
+  const pts: RoutePoint[] = [{ x: sx, y: sy }]
+  let prevY = sy
+  for (const wp of waypoints) {
+    pts.push({ x: wp.x, y: prevY })
+    pts.push({ x: wp.x, y: wp.y })
+    prevY = wp.y
+  }
+  const lastPt = pts[pts.length - 1] as RoutePoint
+  pts.push({ x: lastPt.x, y: ty })
+  pts.push({ x: tx, y: ty })
+  return { kind: 'polyline', points: pts }
+}

--- a/packages/core/src/objects/routing/straight.ts
+++ b/packages/core/src/objects/routing/straight.ts
@@ -1,0 +1,19 @@
+import type { RoutePoint, PolylineRoute } from './types.js'
+
+/**
+ * Straight-line routing — direct line from source to target,
+ * optionally passing through any user-defined waypoints.
+ */
+export function routeStraight(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  waypoints: RoutePoint[],
+): PolylineRoute {
+  const points: RoutePoint[] =
+    waypoints.length > 0
+      ? [{ x: sx, y: sy }, ...waypoints, { x: tx, y: ty }]
+      : [{ x: sx, y: sy }, { x: tx, y: ty }]
+  return { kind: 'polyline', points }
+}

--- a/packages/core/src/objects/routing/types.ts
+++ b/packages/core/src/objects/routing/types.ts
@@ -1,0 +1,32 @@
+/** A 2D point used in routing calculations. */
+export interface RoutePoint {
+  x: number
+  y: number
+}
+
+/** A route made of straight line segments through a sequence of points. */
+export interface PolylineRoute {
+  kind: 'polyline'
+  points: RoutePoint[]
+}
+
+/** A single cubic bezier segment. */
+export interface BezierSegment {
+  p0: RoutePoint
+  /** Control point 1 */
+  p1: RoutePoint
+  /** Control point 2 */
+  p2: RoutePoint
+  p3: RoutePoint
+}
+
+/** A route made of one or more cubic bezier segments. */
+export interface CubicBezierRoute {
+  kind: 'cubic-bezier'
+  segments: BezierSegment[]
+}
+
+export type Route = PolylineRoute | CubicBezierRoute
+
+/** Routing algorithm for Connector objects. */
+export type ConnectorRouting = 'straight' | 'orthogonal' | 'curved'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -118,6 +118,8 @@ export interface RenderContext {
   pixelRatio: number
   /** Current viewport state. */
   viewport: ViewportState
+  /** The stage — used by Connector to resolve object port positions at render time. */
+  stage: StageInterface
 }
 
 // ---------------------------------------------------------------------------
@@ -368,6 +370,8 @@ export interface StageInterface {
   find(predicate: (obj: BaseObject) => boolean): BaseObject[]
   /** Find all objects of a specific type string (e.g. "Rect", "Circle"). */
   findByType(type: string): BaseObject[]
+  /** Find an object by its id across all layers. Returns undefined if not found. */
+  getObjectById(id: string): BaseObject | undefined
   /**
    * Register a custom object type for deserialization.
    * Once registered, `loadJSON()` will use the provided deserializer whenever

--- a/packages/core/tests/__mocks__/canvaskit.ts
+++ b/packages/core/tests/__mocks__/canvaskit.ts
@@ -132,9 +132,17 @@ export function createMockCK() {
     LTRBRect: (l: number, t: number, r: number, b: number) => new Float32Array([l, t, r, b]),
     RRectXY: (rect: Float32Array, rx: number, ry: number) =>
       new Float32Array([...rect, rx, ry, rx, ry, rx, ry, rx, ry]),
-    Path: {
-      MakeFromSVGString: (_svg: string) => createMockPath(),
-    },
+    Path: Object.assign(
+      class {
+        calls: string[] = []
+        moveTo() { this.calls.push('moveTo') }
+        lineTo() { this.calls.push('lineTo') }
+        cubicTo() { this.calls.push('cubicTo') }
+        close() {}
+        delete() {}
+      },
+      { MakeFromSVGString: (_svg: string) => createMockPath() },
+    ),
     TextAlign: { Left: 'Left', Center: 'Center', Right: 'Right' },
     FontWeight: { Normal: 400, Bold: 700, 400: 400, 700: 700 },
     FontWidth: { Normal: 5 },

--- a/packages/core/tests/objects/Connector.test.ts
+++ b/packages/core/tests/objects/Connector.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from 'vitest'
+import { Connector } from '../../src/objects/Connector.js'
+import { Rect } from '../../src/objects/Rect.js'
+import { createMockCK, createMockCanvas } from '../__mocks__/canvaskit.js'
+import { objectFromJSON } from '../../src/objects/objectFromJSON.js'
+import type { RenderContext, StageInterface } from '../../src/types.js'
+import type { FontManager } from '../../src/FontManager.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStage(objects: Rect[] = []): StageInterface {
+  return {
+    getObjectById: (id: string) => objects.find((o) => o.id === id),
+    find: (pred: (o: unknown) => boolean) => objects.filter(pred as (o: Rect) => boolean),
+    findByType: () => [],
+    layers: [],
+    viewport: {} as StageInterface['viewport'],
+    fonts: {} as FontManager,
+    canvasKit: {} as StageInterface['canvasKit'],
+    id: 'mock-stage',
+    on: () => {},
+    off: () => {},
+    emit: () => {},
+    addRenderPass: () => {},
+    removeRenderPass: () => {},
+    getBoundingBox: () => ({ x: 0, y: 0, width: 0, height: 0 }) as never,
+    render: () => {},
+    markDirty: () => {},
+    resize: () => {},
+    registerObject: () => {},
+    getObjectLayer: () => null,
+    bringToFront: () => {},
+    sendToBack: () => {},
+    bringForward: () => {},
+    sendBackward: () => {},
+    groupObjects: () => ({}) as never,
+    ungroupObject: () => [],
+    batch: (fn: () => void) => fn(),
+  } as unknown as StageInterface
+}
+
+function makeCtx(stage?: StageInterface) {
+  const ck = createMockCK()
+  const canvas = createMockCanvas()
+  const ctx: RenderContext = {
+    skCanvas: canvas,
+    canvasKit: ck,
+    fontManager: null,
+    pixelRatio: 1,
+    viewport: { x: 0, y: 0, scale: 1, width: 800, height: 600 },
+    stage: stage ?? makeStage(),
+  }
+  return { ctx, canvas, ck }
+}
+
+// ---------------------------------------------------------------------------
+// Construction & defaults
+// ---------------------------------------------------------------------------
+
+describe('Connector — construction', () => {
+  it('creates with fixed endpoints and defaults', () => {
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 100 } })
+    expect(c.getType()).toBe('Connector')
+    expect(c.routing).toBe('straight')
+    expect(c.label).toBe('')
+    expect(c.labelOffset).toBe(0.5)
+    expect(c.waypoints).toEqual([])
+  })
+
+  it('accepts all routing modes', () => {
+    const straight = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 }, routing: 'straight' })
+    const ortho = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 }, routing: 'orthogonal' })
+    const curved = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 }, routing: 'curved' })
+    expect(straight.routing).toBe('straight')
+    expect(ortho.routing).toBe('orthogonal')
+    expect(curved.routing).toBe('curved')
+  })
+
+  it('sets label and labelOffset', () => {
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 }, label: 'Yes', labelOffset: 0.3 })
+    expect(c.label).toBe('Yes')
+    expect(c.labelOffset).toBe(0.3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Render — fixed endpoints
+// ---------------------------------------------------------------------------
+
+describe('Connector — render (fixed endpoints)', () => {
+  it('renders straight connector — calls drawPath', () => {
+    const { ctx, canvas } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    c.render(ctx)
+    expect(canvas.calls.some((c) => c.method === 'drawPath')).toBe(true)
+  })
+
+  it('renders orthogonal connector', () => {
+    const { ctx, canvas } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 100 }, routing: 'orthogonal' })
+    c.render(ctx)
+    expect(canvas.calls.some((c) => c.method === 'drawPath')).toBe(true)
+  })
+
+  it('renders curved connector', () => {
+    const { ctx, canvas } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 100 }, routing: 'curved' })
+    c.render(ctx)
+    expect(canvas.calls.some((c) => c.method === 'drawPath')).toBe(true)
+  })
+
+  it('does not render when invisible', () => {
+    const { ctx, canvas } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 }, visible: false })
+    c.render(ctx)
+    expect(canvas.calls.some((c) => c.method === 'drawPath')).toBe(false)
+  })
+
+  it('uses save/restore around draw', () => {
+    const { ctx, canvas } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    c.render(ctx)
+    const saves = canvas.calls.filter((c) => c.method === 'save').length
+    const restores = canvas.calls.filter((c) => c.method === 'restore').length
+    expect(saves).toBe(restores)
+    expect(saves).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Render — object port references
+// ---------------------------------------------------------------------------
+
+describe('Connector — render (port references)', () => {
+  it('resolves source and target from object ports', () => {
+    const rect1 = new Rect({ id: 'r1', x: 0, y: 0, width: 100, height: 60 })
+    const rect2 = new Rect({ id: 'r2', x: 300, y: 0, width: 100, height: 60 })
+    const stage = makeStage([rect1, rect2])
+    const { ctx, canvas } = makeCtx(stage)
+
+    const c = new Connector({
+      source: { objectId: 'r1', portId: 'right' },
+      target: { objectId: 'r2', portId: 'left' },
+    })
+    c.render(ctx)
+    expect(canvas.calls.some((c) => c.method === 'drawPath')).toBe(true)
+  })
+
+  it('skips render when objectId not found', () => {
+    const { ctx, canvas } = makeCtx(makeStage([]))
+    const c = new Connector({
+      source: { objectId: 'missing', portId: 'right' },
+      target: { x: 200, y: 0 },
+    })
+    c.render(ctx)
+    expect(canvas.calls.some((c) => c.method === 'drawPath')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bounding box
+// ---------------------------------------------------------------------------
+
+describe('Connector — getLocalBoundingBox', () => {
+  it('returns bbox from fixed endpoints before first render', () => {
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 200, y: 100 } })
+    const bb = c.getLocalBoundingBox()
+    expect(bb.width).toBeGreaterThan(0)
+    expect(bb.height).toBeGreaterThan(0)
+  })
+
+  it('updates bbox after render', () => {
+    const { ctx } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 200, y: 0 }, routing: 'straight' })
+    c.render(ctx)
+    const bb = c.getLocalBoundingBox()
+    // bbox must span at least the full x range of the straight line
+    expect(bb.x).toBeLessThanOrEqual(0)
+    expect(bb.x + bb.width).toBeGreaterThanOrEqual(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Hit testing
+// ---------------------------------------------------------------------------
+
+describe('Connector — hitTest', () => {
+  it('returns false before first render (no cached route)', () => {
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    expect(c.hitTest(50, 0)).toBe(false)
+  })
+
+  it('hits on a straight horizontal line', () => {
+    const { ctx } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    c.render(ctx)
+    expect(c.hitTest(50, 0, 8)).toBe(true)
+  })
+
+  it('misses far from the line', () => {
+    const { ctx } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    c.render(ctx)
+    expect(c.hitTest(50, 100, 8)).toBe(false)
+  })
+
+  it('hits on orthogonal connector corners', () => {
+    const { ctx } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 100 }, routing: 'orthogonal' })
+    c.render(ctx)
+    // midpoint column x=50 should be hit
+    expect(c.hitTest(50, 50, 8)).toBe(true)
+  })
+
+  it('returns false when invisible', () => {
+    const { ctx } = makeCtx()
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 }, visible: false })
+    c.render(ctx)
+    expect(c.hitTest(50, 0)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Serialization round-trip
+// ---------------------------------------------------------------------------
+
+describe('Connector — serialization', () => {
+  it('round-trips via toJSON / fromJSON', () => {
+    const c = new Connector({
+      source: { x: 10, y: 20 },
+      target: { objectId: 'rect-1', portId: 'left' },
+      routing: 'orthogonal',
+      label: 'Yes',
+      labelOffset: 0.3,
+      waypoints: [{ x: 50, y: 50 }],
+    })
+
+    const json = c.toJSON()
+    expect(json.type).toBe('Connector')
+    expect(json.sourceRef).toEqual({ x: 10, y: 20 })
+    expect(json.targetRef).toEqual({ objectId: 'rect-1', portId: 'left' })
+    expect(json.routing).toBe('orthogonal')
+    expect(json.label).toBe('Yes')
+    expect(json.labelOffset).toBe(0.3)
+    expect(json.waypoints).toEqual([{ x: 50, y: 50 }])
+
+    const restored = Connector.fromJSON(json)
+    expect(restored.routing).toBe('orthogonal')
+    expect(restored.label).toBe('Yes')
+    expect(restored.labelOffset).toBe(0.3)
+    expect(restored.waypoints).toEqual([{ x: 50, y: 50 }])
+    const src = restored.source as { x: number; y: number }
+    expect(src.x).toBe(10)
+    expect(src.y).toBe(20)
+  })
+
+  it('objectFromJSON dispatches to Connector', () => {
+    const c = new Connector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    const restored = objectFromJSON(c.toJSON())
+    expect(restored).toBeInstanceOf(Connector)
+  })
+
+  it('round-trips ref endpoints', () => {
+    const c = new Connector({
+      source: { objectId: 'a', portId: 'right' },
+      target: { objectId: 'b', portId: 'left' },
+    })
+    const restored = Connector.fromJSON(c.toJSON())
+    const src = restored.source as { objectId: string; portId: string }
+    expect(src.objectId).toBe('a')
+    expect(src.portId).toBe('right')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Waypoints
+// ---------------------------------------------------------------------------
+
+describe('Connector — waypoints', () => {
+  it('straight routing with waypoint passes through it', () => {
+    const { ctx } = makeCtx()
+    const c = new Connector({
+      source: { x: 0, y: 0 },
+      target: { x: 100, y: 0 },
+      routing: 'straight',
+      waypoints: [{ x: 50, y: 30 }],
+    })
+    c.render(ctx)
+    // Should hit near the waypoint
+    expect(c.hitTest(50, 30, 4)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Path caching
+// ---------------------------------------------------------------------------
+
+describe('Connector — path caching', () => {
+  it('renders drawPath on each frame', () => {
+    const { ctx } = makeCtx()
+    const canvas = ctx.skCanvas as ReturnType<typeof createMockCanvas>
+    const c = new Connector({
+      source: { x: 0, y: 0 },
+      target: { x: 100, y: 0 },
+      stroke: { color: { r: 0, g: 0, b: 0, a: 1 }, width: 2 }, // no arrowheads
+    })
+    c.render(ctx)
+    const after1 = canvas.calls.filter((x) => x.method === 'drawPath').length
+    c.render(ctx)
+    const after2 = canvas.calls.filter((x) => x.method === 'drawPath').length
+    expect(after1).toBeGreaterThan(0)
+    expect(after2).toBe(after1 * 2)
+  })
+})

--- a/packages/plugins/export/src/ExportPlugin.ts
+++ b/packages/plugins/export/src/ExportPlugin.ts
@@ -127,7 +127,7 @@ export class ExportPlugin implements Plugin {
   /** Export to PDF. Returns a Blob containing the PDF bytes. */
   async exportPDF(options: ExportOptions = {}): Promise<Blob> {
     if (!this._stage) throw new Error('[ExportPlugin] Plugin is not installed.')
-    const ck = this._stage.canvasKit as ExportCK
+    const ck = this._stage.canvasKit as unknown as ExportCK
     const region = this._resolveRegion(options)
     const scale = options.scale ?? 1
     const w = region.width * scale
@@ -168,7 +168,7 @@ export class ExportPlugin implements Plugin {
     quality = 90,
   ): Promise<Uint8Array> {
     if (!this._stage) throw new Error('[ExportPlugin] Plugin is not installed.')
-    const ck = this._stage.canvasKit as ExportCK
+    const ck = this._stage.canvasKit as unknown as ExportCK
     const region = this._resolveRegion(options)
     const scale = options.scale ?? 1
     const w = Math.ceil(region.width * scale)
@@ -223,6 +223,7 @@ export class ExportPlugin implements Plugin {
       canvasKit: this._stage.canvasKit,
       fontManager: this._stage.fonts,
       pixelRatio: scale,
+      stage: this._stage,
       viewport: {
         x: -region.x * scale,
         y: -region.y * scale,

--- a/packages/plugins/history/src/HistoryPlugin.ts
+++ b/packages/plugins/history/src/HistoryPlugin.ts
@@ -53,14 +53,14 @@ class BatchPropertyCommand implements HistoryCommand {
 
   apply(): void {
     for (const m of this.mutations) {
-      ;(m.object as Record<string, unknown>)[m.property] = m.newValue
+      ;(m.object as unknown as Record<string, unknown>)[m.property] = m.newValue
     }
   }
 
   undo(): void {
     for (let i = this.mutations.length - 1; i >= 0; i--) {
       const m = this.mutations[i]!
-      ;(m.object as Record<string, unknown>)[m.property] = m.oldValue
+      ;(m.object as unknown as Record<string, unknown>)[m.property] = m.oldValue
     }
   }
 }
@@ -229,8 +229,8 @@ export class HistoryPlugin implements Plugin {
    * unsaved changes.
    */
   checkpoint(label?: string): void {
-    this._checkpoints.push({ label, stackIndex: this._undoStack.length })
-    this._stage?.emit('history:checkpoint', { label })
+    this._checkpoints.push({ ...(label !== undefined ? { label } : {}), stackIndex: this._undoStack.length })
+    this._stage?.emit('history:checkpoint', { ...(label !== undefined ? { label } : {}) })
   }
 
   /** All checkpoints recorded since the last clear(). */

--- a/packages/plugins/selection/src/SelectionPlugin.ts
+++ b/packages/plugins/selection/src/SelectionPlugin.ts
@@ -440,7 +440,9 @@ export class SelectionPlugin implements Plugin {
       startWorldY: e.world.y,
       initialPositions,
       ...(handle !== undefined && { handle }),
-      ...(rotCenterX !== undefined && { rotCenterX, rotCenterY, startAngle }),
+      ...(rotCenterX !== undefined && rotCenterY !== undefined && startAngle !== undefined
+        ? { rotCenterX, rotCenterY, startAngle }
+        : {}),
     }
   }
 
@@ -724,7 +726,7 @@ export class SelectionPlugin implements Plugin {
 
   private _drawSelection(ctx: RenderContext): void {
     if (this._selected.size === 0 || !ctx.skCanvas || !ctx.canvasKit) return
-    const ck = ctx.canvasKit as SelectionCK
+    const ck = ctx.canvasKit as unknown as SelectionCK
     const canvas = ctx.skCanvas as SkCanvas
     const vp = ctx.viewport
     // invScale keeps stroke widths and handle sizes constant in screen pixels regardless of zoom


### PR DESCRIPTION
### Changes

- objects/routing/types.ts - RoutePoint, PolylineRoute, CubicBezierRoute, BezierSegment, Route, ConnectorRouting types
- objects/routing/straight.ts - direct line through optional waypoints
- objects/routing/orthogonal.ts - right-angle (Manhattan) routing; Z-shape without waypoints, right-angle bends through each
waypoint
- objects/routing/curved.ts - cubic bezier with auto-computed tangent control points; sampleBezier() for hit testing
- objects/Connector.ts - full Connector built-in object: fixed-point or port-ref endpoints, all 3 routing modes, arrowheads,
label at configurable path position, SkPath cache keyed by resolved positions, paint cache, effects, hit testing by
distance-to-segment
- types.ts - RenderContext.stage: StageInterface added (required field); StageInterface.getObjectById() added
- Stage.ts - stage: this threaded into every RenderContext construction
- ExportPlugin.ts - stage field added to its manually-constructed RenderContext; pre-existing cast errors fixed
- 22 Connector tests covering construction, all routing modes, port resolution, bbox, hit testing, serialization round-trip,
waypoints, and path caching

Closes #13 