### PR TITLE
Implement connector plugin

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,18 @@ export {
   type PathProps,
   Group,
   type GroupProps,
+  Connector,
+  type ConnectorProps,
+  type ConnectorEndpoint,
+  type ConnectorEndpointFixed,
+  type ConnectorEndpointRef,
+  type ConnectorJSON,
+  type ConnectorRouting,
+  type RoutePoint,
+  Polygon,
+  type PolygonProps,
+  Star,
+  type StarProps,
 } from './objects/index.js'
 export { objectFromJSON } from './objects/objectFromJSON.js'
 export { migrate, CURRENT_SCHEMA_VERSION } from './migrate.js'
@@ -63,4 +75,5 @@ export type {
   StrokeLineJoin,
   ColorRGBA,
   ObjectMutationEvent,
+  Port,
 } from './types.js'

--- a/packages/plugins/connector/package.json
+++ b/packages/plugins/connector/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-connector",
+  "version": "0.0.1",
+  "description": "ConnectorPlugin for nexvas",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/connector/src/ConnectorPlugin.ts
+++ b/packages/plugins/connector/src/ConnectorPlugin.ts
@@ -1,0 +1,455 @@
+import type {
+  Plugin,
+  StageInterface,
+  CanvasPointerEvent,
+  RenderContext,
+  RenderPass,
+  BaseObject,
+  Port,
+  StrokeStyle,
+} from '@nexvas/core'
+import { Connector, type ConnectorEndpoint, type ConnectorRouting } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// CanvasKit interface stubs for the render pass
+// ---------------------------------------------------------------------------
+
+interface Color4f {
+  (r: number, g: number, b: number, a: number): Float32Array
+}
+
+interface SkPaint {
+  delete(): void
+  setAntiAlias(aa: boolean): void
+  setColor4f(color: Float32Array, colorSpace?: unknown): void
+  setStrokeWidth(w: number): void
+  setStyle(style: unknown): void
+}
+
+interface ConnectorCK {
+  Color4f: Color4f
+  PaintStyle: { Fill: unknown; Stroke: unknown }
+  Paint: new () => SkPaint
+  Path: new () => {
+    moveTo(x: number, y: number): void
+    lineTo(x: number, y: number): void
+    delete(): void
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Options for ConnectorPlugin. */
+export interface ConnectorPluginOptions {
+  /** Default routing for newly created connectors. Default: 'straight'. */
+  defaultRouting?: ConnectorRouting
+  /** Default stroke style for new connectors. */
+  defaultStroke?: StrokeStyle
+  /** Screen-pixel radius within which a port is considered a snap target. Default: 20. */
+  portSnapTolerance?: number
+  /** Called when a connector is successfully created. */
+  onConnect?: (connector: Connector) => void
+}
+
+/** Type augmentation to access ConnectorPlugin through the stage. */
+export interface ConnectorPluginAPI {
+  connector: ConnectorPlugin
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+interface DrawState {
+  /** Fixed world-space source position. */
+  srcX: number
+  srcY: number
+  /** Source endpoint reference, if snapped to a port when the drag started. */
+  srcRef: { objectId: string; portId: string } | null
+  /** Current world-space cursor position. */
+  curX: number
+  curY: number
+  /** Snap target under the cursor, if any. */
+  snapTarget: { obj: BaseObject; port: Port; wx: number; wy: number } | null
+}
+
+interface HoverState {
+  obj: BaseObject
+  ports: Array<{ port: Port; wx: number; wy: number }>
+}
+
+// ---------------------------------------------------------------------------
+// ConnectorPlugin
+// ---------------------------------------------------------------------------
+
+/**
+ * ConnectorPlugin — enables interactive connector drawing on the canvas.
+ *
+ * When connect mode is active, users can drag from any object port to another
+ * object's port (or to a free point) to create a {@link Connector}.
+ *
+ * Usage:
+ * ```ts
+ * const plugin = new ConnectorPlugin()
+ * stage.use(plugin)
+ * plugin.startConnectMode()
+ * ```
+ *
+ * Or create connectors programmatically:
+ * ```ts
+ * plugin.createConnector({ source: { objectId: 'r1', portId: 'right' }, target: { objectId: 'r2', portId: 'left' } })
+ * ```
+ */
+export class ConnectorPlugin implements Plugin {
+  readonly name = 'connector'
+  readonly version = '0.1.0'
+
+  private _stage: StageInterface | null = null
+  private _options: Required<Omit<ConnectorPluginOptions, 'onConnect'>> & {
+    onConnect: NonNullable<ConnectorPluginOptions['onConnect']>
+  }
+
+  /** Whether connector drawing mode is currently active. */
+  private _connectMode = false
+  /** State while a connector is actively being drawn (mouse held down). */
+  private _draw: DrawState | null = null
+  /** Hovered object and its computed port positions. */
+  private _hover: HoverState | null = null
+
+  private _renderPass: RenderPass | null = null
+
+  private _onMouseDown: (e: CanvasPointerEvent) => void
+  private _onMouseMove: (e: CanvasPointerEvent) => void
+  private _onMouseUp: (e: CanvasPointerEvent) => void
+  private _onMouseLeave: (e: CanvasPointerEvent) => void
+
+  constructor(options: ConnectorPluginOptions = {}) {
+    this._options = {
+      defaultRouting: options.defaultRouting ?? 'straight',
+      defaultStroke: options.defaultStroke ?? {
+        color: { r: 0.2, g: 0.2, b: 0.2, a: 1 },
+        width: 2,
+        endArrow: 'filled-arrow',
+      },
+      portSnapTolerance: options.portSnapTolerance ?? 20,
+      onConnect: options.onConnect ?? (() => undefined),
+    }
+
+    this._onMouseDown = this._handleMouseDown.bind(this)
+    this._onMouseMove = this._handleMouseMove.bind(this)
+    this._onMouseUp = this._handleMouseUp.bind(this)
+    this._onMouseLeave = this._handleMouseLeave.bind(this)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plugin lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Install the plugin on a stage. */
+  install(stage: StageInterface): void {
+    this._stage = stage
+    ;(stage as unknown as ConnectorPluginAPI).connector = this
+
+    this._renderPass = {
+      phase: 'post',
+      order: 90,
+      render: (ctx: RenderContext) => this._drawOverlay(ctx),
+    }
+    stage.addRenderPass(this._renderPass)
+
+    stage.on('mousedown', this._onMouseDown)
+    stage.on('mousemove', this._onMouseMove)
+    stage.on('mouseup', this._onMouseUp)
+    stage.on('mouseleave', this._onMouseLeave)
+  }
+
+  /** Uninstall the plugin, removing all event listeners and render passes. */
+  uninstall(stage: StageInterface): void {
+    stage.off('mousedown', this._onMouseDown)
+    stage.off('mousemove', this._onMouseMove)
+    stage.off('mouseup', this._onMouseUp)
+    stage.off('mouseleave', this._onMouseLeave)
+
+    if (this._renderPass) {
+      stage.removeRenderPass(this._renderPass)
+      this._renderPass = null
+    }
+
+    this._draw = null
+    this._hover = null
+    this._connectMode = false
+    this._stage = null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enable connector-drawing mode.
+   * In this mode, hovering over objects shows port indicators and users can
+   * drag from one port to another to create a connector.
+   */
+  startConnectMode(): void {
+    this._connectMode = true
+    this._stage?.markDirty()
+  }
+
+  /**
+   * Disable connector-drawing mode.
+   * Any in-progress connector draw is cancelled.
+   */
+  stopConnectMode(): void {
+    this._connectMode = false
+    this._draw = null
+    this._hover = null
+    this._stage?.markDirty()
+  }
+
+  /** Returns true when connector-drawing mode is active. */
+  isConnectMode(): boolean {
+    return this._connectMode
+  }
+
+  /** Returns true when the user is actively dragging a new connector. */
+  isConnecting(): boolean {
+    return this._draw !== null
+  }
+
+  /**
+   * Programmatically create a connector between two endpoints.
+   * The connector is added to the first layer of the stage.
+   *
+   * @param props - Source and target endpoints, optional routing and label.
+   * @returns The newly created {@link Connector}, or null if no stage is installed.
+   */
+  createConnector(props: {
+    source: ConnectorEndpoint
+    target: ConnectorEndpoint
+    routing?: ConnectorRouting
+    label?: string
+    labelOffset?: number
+  }): Connector | null {
+    if (!this._stage) return null
+    const connector = new Connector({
+      source: props.source,
+      target: props.target,
+      routing: props.routing ?? this._options.defaultRouting,
+      label: props.label,
+      labelOffset: props.labelOffset,
+      stroke: this._options.defaultStroke,
+    })
+    const layer = this._stage.layers[0]
+    if (!layer) return null
+    layer.add(connector)
+    this._options.onConnect(connector)
+    this._stage.markDirty()
+    return connector
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  private _handleMouseDown(e: CanvasPointerEvent): void {
+    if (!this._connectMode || !this._stage || e.stopped) return
+
+    const { x: wx, y: wy } = e.world
+
+    // Try to snap to a port under the cursor
+    const snap = this._findSnapTarget(wx, wy)
+    this._draw = {
+      srcX: snap ? snap.wx : wx,
+      srcY: snap ? snap.wy : wy,
+      srcRef: snap ? { objectId: snap.obj.id, portId: snap.port.id } : null,
+      curX: wx,
+      curY: wy,
+      snapTarget: null,
+    }
+    this._stage.markDirty()
+  }
+
+  private _handleMouseMove(e: CanvasPointerEvent): void {
+    if (!this._connectMode || !this._stage) return
+
+    const { x: wx, y: wy } = e.world
+
+    // Update hover (port indicators)
+    this._hover = this._computeHover(wx, wy)
+
+    if (this._draw) {
+      // Update preview line endpoint + snap target
+      const snap = this._findSnapTarget(wx, wy)
+      this._draw.curX = snap ? snap.wx : wx
+      this._draw.curY = snap ? snap.wy : wy
+      this._draw.snapTarget = snap
+    }
+
+    this._stage.markDirty()
+  }
+
+  private _handleMouseUp(e: CanvasPointerEvent): void {
+    if (!this._draw || !this._stage) return
+
+    const { x: wx, y: wy } = e.world
+    const draw = this._draw
+    const snap = this._findSnapTarget(wx, wy)
+
+    const source: ConnectorEndpoint = draw.srcRef
+      ? draw.srcRef
+      : { x: draw.srcX, y: draw.srcY }
+
+    const target: ConnectorEndpoint = snap
+      ? { objectId: snap.obj.id, portId: snap.port.id }
+      : { x: wx, y: wy }
+
+    this._draw = null
+    this._hover = null
+
+    // Avoid zero-length fixed-to-fixed connectors
+    const isTrivial =
+      !('objectId' in source) &&
+      !('objectId' in target) &&
+      Math.hypot((target as { x: number }).x - (source as { x: number }).x,
+                 (target as { y: number }).y - (source as { y: number }).y) < 4
+
+    if (!isTrivial) {
+      this.createConnector({ source, target })
+    }
+
+    this._stage.markDirty()
+  }
+
+  private _handleMouseLeave(_e: CanvasPointerEvent): void {
+    this._hover = null
+    this._draw = null
+    this._stage?.markDirty()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Port helpers
+  // ---------------------------------------------------------------------------
+
+  /** Compute world positions for all ports on all visible objects near the cursor. */
+  private _computeHover(wx: number, wy: number): HoverState | null {
+    if (!this._stage) return null
+
+    // Find the topmost hittable object under the cursor
+    const layers = this._stage.layers
+    for (let i = layers.length - 1; i >= 0; i--) {
+      const obj = layers[i]!.hitTest(wx, wy)
+      if (obj && !obj.locked) {
+        return {
+          obj,
+          ports: this._getPortWorldPositions(obj),
+        }
+      }
+    }
+    return null
+  }
+
+  private _getPortWorldPositions(obj: BaseObject): Array<{ port: Port; wx: number; wy: number }> {
+    return obj.getPorts().map((port) => {
+      const pos = obj.getPortWorldPosition(port.id)
+      return { port, wx: pos?.x ?? 0, wy: pos?.y ?? 0 }
+    })
+  }
+
+  /** Find a port within snap tolerance of the given world-space point. */
+  private _findSnapTarget(
+    wx: number,
+    wy: number,
+  ): { obj: BaseObject; port: Port; wx: number; wy: number } | null {
+    if (!this._stage) return null
+
+    const viewportScale = this._stage.viewport.scale
+    const worldTol = this._options.portSnapTolerance / viewportScale
+
+    const layers = this._stage.layers
+    for (let i = layers.length - 1; i >= 0; i--) {
+      const objects = layers[i]!.objects
+      for (const obj of objects) {
+        if (!obj.visible || obj.locked) continue
+        for (const port of obj.getPorts()) {
+          const pos = obj.getPortWorldPosition(port.id)
+          if (!pos) continue
+          if (Math.hypot(wx - pos.x, wy - pos.y) <= worldTol) {
+            return { obj, port, wx: pos.x, wy: pos.y }
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render pass overlay
+  // ---------------------------------------------------------------------------
+
+  private _drawOverlay(ctx: RenderContext): void {
+    if (!this._connectMode) return
+    const ck = ctx.canvasKit as unknown as ConnectorCK
+    const canvas = ctx.skCanvas as unknown as {
+      save(): number
+      restore(): void
+      drawCircle(cx: number, cy: number, r: number, paint: SkPaint): void
+      drawPath(path: unknown, paint: SkPaint): void
+    }
+    if (!canvas || !ck?.Paint) return
+
+    const viewportScale = ctx.viewport.scale
+
+    // Draw port indicators on hovered object
+    if (this._hover) {
+      const fillPaint = new ck.Paint()
+      fillPaint.setAntiAlias(true)
+      fillPaint.setStyle(ck.PaintStyle.Fill)
+      fillPaint.setColor4f(ck.Color4f(0.2, 0.5, 1.0, 0.85))
+
+      const strokePaint = new ck.Paint()
+      strokePaint.setAntiAlias(true)
+      strokePaint.setStyle(ck.PaintStyle.Stroke)
+      strokePaint.setColor4f(ck.Color4f(1, 1, 1, 1))
+      strokePaint.setStrokeWidth(1.5 / viewportScale)
+
+      const r = 5 / viewportScale
+
+      for (const { wx, wy } of this._hover.ports) {
+        canvas.drawCircle(wx, wy, r, fillPaint)
+        canvas.drawCircle(wx, wy, r, strokePaint)
+      }
+
+      fillPaint.delete()
+      strokePaint.delete()
+    }
+
+    // Draw snap indicator on active snap target
+    if (this._draw?.snapTarget) {
+      const { wx, wy } = this._draw.snapTarget
+      const snapPaint = new ck.Paint()
+      snapPaint.setAntiAlias(true)
+      snapPaint.setStyle(ck.PaintStyle.Fill)
+      snapPaint.setColor4f(ck.Color4f(0.0, 0.8, 0.4, 0.9))
+      canvas.drawCircle(wx, wy, 7 / viewportScale, snapPaint)
+      snapPaint.delete()
+    }
+
+    // Draw preview line
+    if (this._draw) {
+      const linePaint = new ck.Paint()
+      linePaint.setAntiAlias(true)
+      linePaint.setStyle(ck.PaintStyle.Stroke)
+      linePaint.setStrokeWidth(2 / viewportScale)
+      linePaint.setColor4f(ck.Color4f(0.2, 0.5, 1.0, 0.7))
+
+      const skPath = new ck.Path()
+      skPath.moveTo(this._draw.srcX, this._draw.srcY)
+      skPath.lineTo(this._draw.curX, this._draw.curY)
+      canvas.drawPath(skPath, linePaint)
+      skPath.delete()
+      linePaint.delete()
+    }
+  }
+}

--- a/packages/plugins/connector/src/index.ts
+++ b/packages/plugins/connector/src/index.ts
@@ -1,0 +1,1 @@
+export { ConnectorPlugin, type ConnectorPluginOptions, type ConnectorPluginAPI } from './ConnectorPlugin.js'

--- a/packages/plugins/connector/tests/ConnectorPlugin.test.ts
+++ b/packages/plugins/connector/tests/ConnectorPlugin.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ConnectorPlugin } from '../src/ConnectorPlugin.js'
+import { Rect, Layer, Connector } from '@nexvas/core'
+import type { StageInterface, CanvasPointerEvent, RenderPass, BoundingBox, Viewport, FontManager } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePointerEvent(opts: { worldX?: number; worldY?: number } = {}): CanvasPointerEvent {
+  return {
+    world: { x: opts.worldX ?? 0, y: opts.worldY ?? 0 },
+    screen: { x: opts.worldX ?? 0, y: opts.worldY ?? 0 },
+    originalEvent: {} as MouseEvent,
+    stopped: false,
+    stopPropagation() { this.stopped = true },
+  }
+}
+
+type EventHandler = (e: unknown) => void
+
+function makeStage(layerObjects: Rect[] = []): StageInterface {
+  const layer = new Layer()
+  for (const obj of layerObjects) layer.add(obj)
+
+  const handlers = new Map<string, Set<EventHandler>>()
+  const passes: RenderPass[] = []
+
+  const stage: StageInterface = {
+    id: 'test-stage',
+    canvasKit: {},
+    get layers() {
+      return [layer] as unknown as readonly Layer[]
+    },
+    viewport: {
+      x: 0,
+      y: 0,
+      scale: 1,
+      width: 800,
+      height: 600,
+      getState: () => ({ x: 0, y: 0, scale: 1, width: 800, height: 600 }),
+    } as unknown as Viewport,
+    fonts: {} as unknown as FontManager,
+    on(event: string, handler: EventHandler) {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    },
+    off(event: string, handler: EventHandler) {
+      handlers.get(event)?.delete(handler)
+    },
+    addRenderPass(pass: RenderPass) {
+      passes.push(pass)
+    },
+    removeRenderPass(pass: RenderPass) {
+      const i = passes.indexOf(pass)
+      if (i !== -1) passes.splice(i, 1)
+    },
+    getBoundingBox() {
+      const { BoundingBox: BB } = require('@nexvas/core') as {
+        BoundingBox: new (x: number, y: number, w: number, h: number) => BoundingBox
+      }
+      return new BB(0, 0, 800, 600)
+    },
+    render: vi.fn(),
+    markDirty: vi.fn(),
+    emit: vi.fn(),
+    resize: vi.fn(),
+    find: vi.fn(() => []),
+    findByType: vi.fn(() => []),
+    getObjectById: vi.fn(() => undefined),
+    _fire(event: string, data: unknown) {
+      handlers.get(event)?.forEach((h) => h(data))
+    },
+  } as unknown as StageInterface
+
+  return stage
+}
+
+function fire(stage: StageInterface, event: string, data: unknown) {
+  ;(stage as unknown as { _fire: (e: string, d: unknown) => void })._fire(event, data)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConnectorPlugin', () => {
+  let plugin: ConnectorPlugin
+  let stage: StageInterface
+
+  beforeEach(() => {
+    plugin = new ConnectorPlugin()
+    stage = makeStage()
+    plugin.install(stage)
+  })
+
+  it('installs without throwing', () => {
+    expect(() => plugin.install(makeStage())).not.toThrow()
+  })
+
+  it('uninstalls cleanly', () => {
+    plugin.uninstall(stage)
+    expect(plugin.isConnectMode()).toBe(false)
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('install → uninstall → re-install works', () => {
+    plugin.uninstall(stage)
+    const stage2 = makeStage()
+    expect(() => plugin.install(stage2)).not.toThrow()
+    plugin.uninstall(stage2)
+  })
+
+  it('isConnectMode starts as false', () => {
+    expect(plugin.isConnectMode()).toBe(false)
+  })
+
+  it('startConnectMode / stopConnectMode toggle the mode', () => {
+    plugin.startConnectMode()
+    expect(plugin.isConnectMode()).toBe(true)
+
+    plugin.stopConnectMode()
+    expect(plugin.isConnectMode()).toBe(false)
+  })
+
+  it('isConnecting is false before mousedown', () => {
+    plugin.startConnectMode()
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('isConnecting becomes true after mousedown in connect mode', () => {
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 50, worldY: 50 }))
+    expect(plugin.isConnecting()).toBe(true)
+  })
+
+  it('isConnecting becomes false after mouseup', () => {
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 50, worldY: 50 }))
+    fire(stage, 'mouseup', makePointerEvent({ worldX: 200, worldY: 200 }))
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('does not start connecting when connect mode is off', () => {
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 50, worldY: 50 }))
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('creates a connector on mouseup with sufficient distance', () => {
+    const layer = stage.layers[0]!
+    const initialCount = layer.objects.length
+
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 0, worldY: 0 }))
+    fire(stage, 'mouseup', makePointerEvent({ worldX: 200, worldY: 0 }))
+
+    expect(layer.objects.length).toBe(initialCount + 1)
+    expect(layer.objects[layer.objects.length - 1]).toBeInstanceOf(Connector)
+  })
+
+  it('does not create a connector when distance is trivial (< 4px)', () => {
+    const layer = stage.layers[0]!
+    const initialCount = layer.objects.length
+
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 100, worldY: 100 }))
+    fire(stage, 'mouseup', makePointerEvent({ worldX: 101, worldY: 100 })) // 1px apart
+
+    expect(layer.objects.length).toBe(initialCount)
+  })
+
+  it('calls onConnect callback when connector is created', () => {
+    const onConnect = vi.fn()
+    const p = new ConnectorPlugin({ onConnect })
+    p.install(stage)
+    p.startConnectMode()
+
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 0, worldY: 0 }))
+    fire(stage, 'mouseup', makePointerEvent({ worldX: 300, worldY: 0 }))
+
+    expect(onConnect).toHaveBeenCalledOnce()
+    expect(onConnect.mock.calls[0][0]).toBeInstanceOf(Connector)
+    p.uninstall(stage)
+  })
+
+  it('uninstall stops event handling', () => {
+    plugin.startConnectMode()
+    plugin.uninstall(stage)
+
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 0, worldY: 0 }))
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('mouseleave cancels active draw', () => {
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 0, worldY: 0 }))
+    expect(plugin.isConnecting()).toBe(true)
+    fire(stage, 'mouseleave', makePointerEvent())
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('stopConnectMode cancels active draw', () => {
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 0, worldY: 0 }))
+    plugin.stopConnectMode()
+    expect(plugin.isConnecting()).toBe(false)
+  })
+
+  it('createConnector programmatic API adds connector to first layer', () => {
+    const layer = stage.layers[0]!
+    const connector = plugin.createConnector({
+      source: { x: 0, y: 0 },
+      target: { x: 100, y: 100 },
+    })
+    expect(connector).toBeInstanceOf(Connector)
+    expect(layer.objects).toContain(connector)
+  })
+
+  it('createConnector returns null when plugin is not installed on a stage', () => {
+    const uninstalledPlugin = new ConnectorPlugin()
+    const result = uninstalledPlugin.createConnector({ source: { x: 0, y: 0 }, target: { x: 100, y: 0 } })
+    expect(result).toBeNull()
+  })
+
+  it('connector created programmatically uses default routing', () => {
+    const p = new ConnectorPlugin({ defaultRouting: 'orthogonal' })
+    p.install(stage)
+    const connector = p.createConnector({ source: { x: 0, y: 0 }, target: { x: 100, y: 100 } })
+    expect((connector as Connector).routing).toBe('orthogonal')
+    p.uninstall(stage)
+  })
+
+  it('connector created via drag has fixed endpoints when not snapped to ports', () => {
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 10, worldY: 20 }))
+    fire(stage, 'mouseup', makePointerEvent({ worldX: 300, worldY: 150 }))
+
+    const layer = stage.layers[0]!
+    const connector = layer.objects[layer.objects.length - 1] as Connector
+    expect(connector).toBeInstanceOf(Connector)
+    expect('x' in connector.source).toBe(true)
+    expect('x' in connector.target).toBe(true)
+  })
+
+  it('connector snaps to object port when released near port', () => {
+    const rect = new Rect({ x: 300, y: 100, width: 100, height: 100 })
+    const layer = stage.layers[0]!
+    layer.add(rect)
+
+    // The 'right' port is at x=400, y=150
+    plugin.startConnectMode()
+    fire(stage, 'mousedown', makePointerEvent({ worldX: 10, worldY: 10 }))
+    // Release very close to the right port of rect (within 20px tolerance)
+    fire(stage, 'mouseup', makePointerEvent({ worldX: 402, worldY: 150 }))
+
+    const connector = layer.objects[layer.objects.length - 1] as Connector
+    expect(connector).toBeInstanceOf(Connector)
+    // Target should be a port reference
+    expect('objectId' in connector.target).toBe(true)
+    if ('objectId' in connector.target) {
+      expect(connector.target.objectId).toBe(rect.id)
+      expect(connector.target.portId).toBe('right')
+    }
+  })
+})

--- a/packages/plugins/connector/tsconfig.json
+++ b/packages/plugins/connector/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/plugins/connector/vite.config.ts
+++ b/packages/plugins/connector/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      name: 'CanvasFwPluginConnector',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: ['@nexvas/core'],
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+})

--- a/packages/plugins/connector/vitest.config.ts
+++ b/packages/plugins/connector/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@nexvas/plugin-connector',
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,24 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/connector:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/drag:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
 The plugin provides interactive connector drawing on top of the existing Connector built-in object (already in core).

  API:
  - `plugin.startConnectMode() / stopConnectMode()` - toggle the drawing mode
  - `plugin.isConnectMode() / isConnecting()` - state queries
  - `plugin.createConnector({ source, target, routing?, label? })` - programmatic creation, returns the Connector

  Behavior in connect mode:
  - Hover over an object → port indicators (blue circles) appear at its 5 default ports
  - Mousedown anywhere → starts dragging a preview line from that point (snaps to nearest port within 20px tolerance)
  - While dragging → green snap indicator appears over the nearest port target
  - Mouseup on a port → creates a `Connector` with a `ConnectorEndpointRef` (tracks the object by ID/portId, survives moves)
  - Mouseup on empty space → creates a `Connector` with a fixed `ConnectorEndpointFixed`
  - Trivial connectors (<4px) are discarded; mouseleave cancels the draw

  Also added to `@nexvas/core` public exports: `Connector`, `Polygon`, `Star`, `ConnectorRouting`, `RoutePoint`, `Port` (were in the objects barrel but not re-exported from the root index).