### PR TITLE
Implement align plugin

### DIFF
--- a/packages/plugins/align/package.json
+++ b/packages/plugins/align/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-align",
+  "version": "0.0.1",
+  "description": "Alignment and distribution plugin for NexVas",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/align/src/AlignPlugin.ts
+++ b/packages/plugins/align/src/AlignPlugin.ts
@@ -1,0 +1,245 @@
+import type { Plugin, StageInterface, BaseObject } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The anchor reference used when aligning objects. */
+export type AlignRelativeTo = 'selection' | 'stage' | 'first' | BaseObject
+
+/** Options for AlignPlugin. */
+export interface AlignPluginOptions {
+  /** Default reference for alignment operations. Default: 'selection'. */
+  defaultRelativeTo?: AlignRelativeTo
+}
+
+/** Type augmentation to access AlignPlugin API through the stage. */
+export interface AlignPluginAPI {
+  align: AlignController
+}
+
+// ---------------------------------------------------------------------------
+// AlignController
+// ---------------------------------------------------------------------------
+
+/**
+ * Provides alignment and distribution methods for a set of objects.
+ * All mutations are wrapped in `stage.batch()` so HistoryPlugin records one undo entry.
+ */
+export class AlignController {
+  private _stage: StageInterface
+
+  constructor(stage: StageInterface) {
+    this._stage = stage
+  }
+
+  // -------------------------------------------------------------------------
+  // Alignment helpers
+  // -------------------------------------------------------------------------
+
+  /** Align all objects so their left edges match the anchor's left edge. */
+  left(objects: BaseObject[], options?: { relativeTo?: AlignRelativeTo }): void {
+    if (objects.length === 0) return
+    const anchor = this._resolveAnchor(objects, options?.relativeTo ?? 'selection')
+    const targetX = anchor.x
+    this._stage.batch(() => {
+      for (const obj of objects) {
+        const bb = obj.getWorldBoundingBox()
+        obj.x += targetX - bb.x
+      }
+    })
+  }
+
+  /** Align all objects so their centers share the same horizontal position. */
+  centerHorizontal(objects: BaseObject[], options?: { relativeTo?: AlignRelativeTo }): void {
+    if (objects.length === 0) return
+    const anchor = this._resolveAnchor(objects, options?.relativeTo ?? 'selection')
+    const targetCX = anchor.x + anchor.width / 2
+    this._stage.batch(() => {
+      for (const obj of objects) {
+        const bb = obj.getWorldBoundingBox()
+        obj.x += targetCX - (bb.x + bb.width / 2)
+      }
+    })
+  }
+
+  /** Align all objects so their right edges match the anchor's right edge. */
+  right(objects: BaseObject[], options?: { relativeTo?: AlignRelativeTo }): void {
+    if (objects.length === 0) return
+    const anchor = this._resolveAnchor(objects, options?.relativeTo ?? 'selection')
+    const targetRight = anchor.x + anchor.width
+    this._stage.batch(() => {
+      for (const obj of objects) {
+        const bb = obj.getWorldBoundingBox()
+        obj.x += targetRight - (bb.x + bb.width)
+      }
+    })
+  }
+
+  /** Align all objects so their top edges match the anchor's top edge. */
+  top(objects: BaseObject[], options?: { relativeTo?: AlignRelativeTo }): void {
+    if (objects.length === 0) return
+    const anchor = this._resolveAnchor(objects, options?.relativeTo ?? 'selection')
+    const targetY = anchor.y
+    this._stage.batch(() => {
+      for (const obj of objects) {
+        const bb = obj.getWorldBoundingBox()
+        obj.y += targetY - bb.y
+      }
+    })
+  }
+
+  /** Align all objects so their centers share the same vertical position. */
+  centerVertical(objects: BaseObject[], options?: { relativeTo?: AlignRelativeTo }): void {
+    if (objects.length === 0) return
+    const anchor = this._resolveAnchor(objects, options?.relativeTo ?? 'selection')
+    const targetCY = anchor.y + anchor.height / 2
+    this._stage.batch(() => {
+      for (const obj of objects) {
+        const bb = obj.getWorldBoundingBox()
+        obj.y += targetCY - (bb.y + bb.height / 2)
+      }
+    })
+  }
+
+  /** Align all objects so their bottom edges match the anchor's bottom edge. */
+  bottom(objects: BaseObject[], options?: { relativeTo?: AlignRelativeTo }): void {
+    if (objects.length === 0) return
+    const anchor = this._resolveAnchor(objects, options?.relativeTo ?? 'selection')
+    const targetBottom = anchor.y + anchor.height
+    this._stage.batch(() => {
+      for (const obj of objects) {
+        const bb = obj.getWorldBoundingBox()
+        obj.y += targetBottom - (bb.y + bb.height)
+      }
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Distribution helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Space objects evenly along the horizontal axis.
+   * Leftmost and rightmost objects stay fixed; inner objects are repositioned.
+   * Requires at least 3 objects to have any effect.
+   */
+  distributeHorizontally(objects: BaseObject[]): void {
+    if (objects.length < 3) return
+    const sorted = [...objects].sort((a, b) => a.getWorldBoundingBox().x - b.getWorldBoundingBox().x)
+    const first = sorted[0].getWorldBoundingBox()
+    const last = sorted[sorted.length - 1].getWorldBoundingBox()
+    const totalWidth = sorted.reduce((sum, o) => sum + o.getWorldBoundingBox().width, 0)
+    const gap = (last.x + last.width - first.x - totalWidth) / (sorted.length - 1)
+    this._stage.batch(() => {
+      let cursor = first.x + first.width + gap
+      for (let i = 1; i < sorted.length - 1; i++) {
+        const bb = sorted[i].getWorldBoundingBox()
+        sorted[i].x += cursor - bb.x
+        cursor += bb.width + gap
+      }
+    })
+  }
+
+  /**
+   * Space objects evenly along the vertical axis.
+   * Topmost and bottommost objects stay fixed; inner objects are repositioned.
+   * Requires at least 3 objects to have any effect.
+   */
+  distributeVertically(objects: BaseObject[]): void {
+    if (objects.length < 3) return
+    const sorted = [...objects].sort((a, b) => a.getWorldBoundingBox().y - b.getWorldBoundingBox().y)
+    const first = sorted[0].getWorldBoundingBox()
+    const last = sorted[sorted.length - 1].getWorldBoundingBox()
+    const totalHeight = sorted.reduce((sum, o) => sum + o.getWorldBoundingBox().height, 0)
+    const gap = (last.y + last.height - first.y - totalHeight) / (sorted.length - 1)
+    this._stage.batch(() => {
+      let cursor = first.y + first.height + gap
+      for (let i = 1; i < sorted.length - 1; i++) {
+        const bb = sorted[i].getWorldBoundingBox()
+        sorted[i].y += cursor - bb.y
+        cursor += bb.height + gap
+      }
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private _resolveAnchor(
+    objects: BaseObject[],
+    relativeTo: AlignRelativeTo,
+  ): { x: number; y: number; width: number; height: number } {
+    if (relativeTo === 'stage') {
+      const bb = this._stage.getBoundingBox()
+      return { x: bb.x, y: bb.y, width: bb.width, height: bb.height }
+    }
+
+    if (relativeTo === 'first') {
+      const bb = objects[0].getWorldBoundingBox()
+      return { x: bb.x, y: bb.y, width: bb.width, height: bb.height }
+    }
+
+    if (relativeTo !== 'selection') {
+      // Specific BaseObject anchor
+      const bb = relativeTo.getWorldBoundingBox()
+      return { x: bb.x, y: bb.y, width: bb.width, height: bb.height }
+    }
+
+    // 'selection' — compute union bounding box of all objects
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const obj of objects) {
+      const bb = obj.getWorldBoundingBox()
+      if (bb.x < minX) minX = bb.x
+      if (bb.y < minY) minY = bb.y
+      if (bb.x + bb.width > maxX) maxX = bb.x + bb.width
+      if (bb.y + bb.height > maxY) maxY = bb.y + bb.height
+    }
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AlignPlugin
+// ---------------------------------------------------------------------------
+
+/**
+ * AlignPlugin — alignment and distribution for canvas objects.
+ *
+ * After installing, access alignment operations via `(stage as AlignPluginAPI).align`.
+ * All mutations go through `stage.batch()` so HistoryPlugin records a single undo entry.
+ *
+ * @example
+ * ```ts
+ * stage.use(new AlignPlugin())
+ * const { align } = stage as unknown as AlignPluginAPI
+ *
+ * align.left(selectedObjects)
+ * align.distributeHorizontally(selectedObjects)
+ * align.centerVertical(selectedObjects, { relativeTo: 'stage' })
+ * ```
+ */
+export class AlignPlugin implements Plugin {
+  readonly name = 'plugin-align'
+  readonly version = '0.0.1'
+
+  private _controller: AlignController | null = null
+  private _stage: StageInterface | null = null
+
+  constructor(_options: AlignPluginOptions = {}) {}
+
+  /** Install the plugin on a stage. Attaches the `align` controller to the stage object. */
+  install(stage: StageInterface): void {
+    this._stage = stage
+    this._controller = new AlignController(stage)
+    ;(stage as unknown as AlignPluginAPI).align = this._controller
+  }
+
+  /** Remove the plugin. Detaches the `align` controller from the stage object. */
+  uninstall(stage: StageInterface): void {
+    delete (stage as unknown as Partial<AlignPluginAPI>).align
+    this._controller = null
+    this._stage = null
+  }
+}

--- a/packages/plugins/align/src/AlignPlugin.ts
+++ b/packages/plugins/align/src/AlignPlugin.ts
@@ -127,15 +127,16 @@ export class AlignController {
   distributeHorizontally(objects: BaseObject[]): void {
     if (objects.length < 3) return
     const sorted = [...objects].sort((a, b) => a.getWorldBoundingBox().x - b.getWorldBoundingBox().x)
-    const first = sorted[0].getWorldBoundingBox()
-    const last = sorted[sorted.length - 1].getWorldBoundingBox()
+    // ! is safe: early return above guarantees sorted.length >= 3
+    const first = sorted[0]!.getWorldBoundingBox()
+    const last = sorted[sorted.length - 1]!.getWorldBoundingBox()
     const totalWidth = sorted.reduce((sum, o) => sum + o.getWorldBoundingBox().width, 0)
     const gap = (last.x + last.width - first.x - totalWidth) / (sorted.length - 1)
     this._stage.batch(() => {
       let cursor = first.x + first.width + gap
       for (let i = 1; i < sorted.length - 1; i++) {
-        const bb = sorted[i].getWorldBoundingBox()
-        sorted[i].x += cursor - bb.x
+        const bb = sorted[i]!.getWorldBoundingBox()
+        sorted[i]!.x += cursor - bb.x
         cursor += bb.width + gap
       }
     })
@@ -149,15 +150,16 @@ export class AlignController {
   distributeVertically(objects: BaseObject[]): void {
     if (objects.length < 3) return
     const sorted = [...objects].sort((a, b) => a.getWorldBoundingBox().y - b.getWorldBoundingBox().y)
-    const first = sorted[0].getWorldBoundingBox()
-    const last = sorted[sorted.length - 1].getWorldBoundingBox()
+    // ! is safe: early return above guarantees sorted.length >= 3
+    const first = sorted[0]!.getWorldBoundingBox()
+    const last = sorted[sorted.length - 1]!.getWorldBoundingBox()
     const totalHeight = sorted.reduce((sum, o) => sum + o.getWorldBoundingBox().height, 0)
     const gap = (last.y + last.height - first.y - totalHeight) / (sorted.length - 1)
     this._stage.batch(() => {
       let cursor = first.y + first.height + gap
       for (let i = 1; i < sorted.length - 1; i++) {
-        const bb = sorted[i].getWorldBoundingBox()
-        sorted[i].y += cursor - bb.y
+        const bb = sorted[i]!.getWorldBoundingBox()
+        sorted[i]!.y += cursor - bb.y
         cursor += bb.height + gap
       }
     })
@@ -177,7 +179,8 @@ export class AlignController {
     }
 
     if (relativeTo === 'first') {
-      const bb = objects[0].getWorldBoundingBox()
+      // ! is safe: callers must pass a non-empty objects array (enforced by all public align methods)
+      const bb = objects[0]!.getWorldBoundingBox()
       return { x: bb.x, y: bb.y, width: bb.width, height: bb.height }
     }
 

--- a/packages/plugins/align/src/index.ts
+++ b/packages/plugins/align/src/index.ts
@@ -1,0 +1,1 @@
+export { AlignPlugin, AlignController, type AlignPluginOptions, type AlignPluginAPI, type AlignRelativeTo } from './AlignPlugin.js'

--- a/packages/plugins/align/tests/AlignPlugin.test.ts
+++ b/packages/plugins/align/tests/AlignPlugin.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { AlignPlugin, type AlignPluginAPI } from '../src/AlignPlugin.js'
+import { Rect, Layer, BoundingBox } from '@nexvas/core'
+import type { StageInterface, Viewport, FontManager, RenderPass } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStage(): StageInterface {
+  const layer = new Layer()
+  const handlers = new Map<string, Set<(e: unknown) => void>>()
+  const passes: RenderPass[] = []
+
+  const stage: StageInterface = {
+    id: 'test-stage',
+    canvasKit: {},
+    get layers() { return [layer] as unknown as readonly Layer[] },
+    viewport: { x: 0, y: 0, scale: 1, width: 800, height: 600 } as unknown as Viewport,
+    fonts: {} as unknown as FontManager,
+    on(event: string, handler: (e: unknown) => void) {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    },
+    off(event: string, handler: (e: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+    },
+    emit(event: string, data: unknown) {
+      handlers.get(event)?.forEach((h) => h(data))
+    },
+    addRenderPass(pass: RenderPass) { passes.push(pass) },
+    removeRenderPass(pass: RenderPass) {
+      const i = passes.indexOf(pass)
+      if (i !== -1) passes.splice(i, 1)
+    },
+    getBoundingBox() { return new BoundingBox(0, 0, 800, 600) },
+    render() {},
+    markDirty() {},
+    resize() {},
+    find: () => [],
+    findByType: () => [],
+    getObjectById: () => undefined,
+    registerObject: () => {},
+    getObjectLayer: () => null,
+    bringToFront: () => {},
+    sendToBack: () => {},
+    bringForward: () => {},
+    sendBackward: () => {},
+    groupObjects: () => { throw new Error('not implemented') },
+    ungroupObject: () => [],
+    batch(fn: () => void) { fn() },
+  } as unknown as StageInterface
+
+  return stage
+}
+
+function makeRect(x: number, y: number, w: number, h: number): Rect {
+  return new Rect({ x, y, width: w, height: h })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AlignPlugin', () => {
+  let plugin: AlignPlugin
+  let stage: StageInterface
+
+  beforeEach(() => {
+    plugin = new AlignPlugin()
+    stage = makeStage()
+    plugin.install(stage)
+  })
+
+  // --- lifecycle -----------------------------------------------------------
+
+  it('installs without throwing', () => {
+    const s = makeStage()
+    expect(() => new AlignPlugin().install(s)).not.toThrow()
+  })
+
+  it('exposes align controller after install', () => {
+    expect((stage as unknown as AlignPluginAPI).align).toBeDefined()
+  })
+
+  it('uninstalls cleanly — removes align from stage', () => {
+    plugin.uninstall(stage)
+    expect((stage as unknown as Partial<AlignPluginAPI>).align).toBeUndefined()
+  })
+
+  it('install → uninstall → re-install works correctly', () => {
+    plugin.uninstall(stage)
+    const stage2 = makeStage()
+    expect(() => plugin.install(stage2)).not.toThrow()
+    expect((stage2 as unknown as AlignPluginAPI).align).toBeDefined()
+    plugin.uninstall(stage2)
+    expect((stage2 as unknown as Partial<AlignPluginAPI>).align).toBeUndefined()
+  })
+
+  // --- align.left ----------------------------------------------------------
+
+  describe('align.left', () => {
+    it('aligns all objects to the leftmost edge of the selection', () => {
+      const a = makeRect(50, 10, 80, 40)
+      const b = makeRect(200, 30, 60, 40)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.left([a, b])
+      // leftmost is a at x=50; b should move to x=50
+      expect(b.x).toBe(50)
+      expect(a.x).toBe(50) // unchanged
+    })
+
+    it('aligns to stage when relativeTo="stage"', () => {
+      const a = makeRect(100, 50, 80, 40)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.left([a], { relativeTo: 'stage' })
+      expect(a.x).toBe(0)
+    })
+
+    it('aligns to first object when relativeTo="first"', () => {
+      const a = makeRect(300, 0, 50, 50)
+      const b = makeRect(100, 0, 50, 50)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.left([a, b], { relativeTo: 'first' })
+      // anchor is a (first), so b moves to x=300
+      expect(b.x).toBe(300)
+    })
+
+    it('aligns to a specific BaseObject anchor', () => {
+      const anchor = makeRect(70, 0, 50, 50)
+      const a = makeRect(200, 0, 50, 50)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.left([a], { relativeTo: anchor })
+      expect(a.x).toBe(70)
+    })
+
+    it('does nothing for empty array', () => {
+      expect(() => (stage as unknown as AlignPluginAPI).align.left([])).not.toThrow()
+    })
+  })
+
+  // --- align.right ---------------------------------------------------------
+
+  describe('align.right', () => {
+    it('aligns all objects so their right edges match the selection right edge', () => {
+      const a = makeRect(0, 0, 100, 50)   // right = 100
+      const b = makeRect(0, 60, 60, 50)   // right = 60
+      const { align } = stage as unknown as AlignPluginAPI
+      align.right([a, b])
+      // selection right = max(100, 60) = 100; b.right should become 100 → b.x = 40
+      expect(b.x).toBeCloseTo(40)
+      expect(a.x).toBeCloseTo(0)
+    })
+  })
+
+  // --- align.centerHorizontal ----------------------------------------------
+
+  describe('align.centerHorizontal', () => {
+    it('centers objects on the horizontal axis of the selection', () => {
+      const a = makeRect(0, 0, 100, 50)   // cx = 50
+      const b = makeRect(200, 60, 100, 50) // cx = 250
+      const { align } = stage as unknown as AlignPluginAPI
+      align.centerHorizontal([a, b])
+      // selection: x=0, width=300, cx=150
+      expect(a.x).toBeCloseTo(100)  // 150 - 100/2 = 100
+      expect(b.x).toBeCloseTo(100)
+    })
+  })
+
+  // --- align.top -----------------------------------------------------------
+
+  describe('align.top', () => {
+    it('aligns all objects to the topmost edge of the selection', () => {
+      const a = makeRect(0, 20, 50, 50)
+      const b = makeRect(0, 80, 50, 50)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.top([a, b])
+      expect(a.y).toBe(20)
+      expect(b.y).toBe(20)
+    })
+
+    it('aligns to stage top when relativeTo="stage"', () => {
+      const a = makeRect(0, 100, 50, 50)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.top([a], { relativeTo: 'stage' })
+      expect(a.y).toBe(0)
+    })
+  })
+
+  // --- align.bottom --------------------------------------------------------
+
+  describe('align.bottom', () => {
+    it('aligns all objects so their bottom edges match the selection bottom', () => {
+      const a = makeRect(0, 0, 50, 100)  // bottom = 100
+      const b = makeRect(60, 0, 50, 60)  // bottom = 60
+      const { align } = stage as unknown as AlignPluginAPI
+      align.bottom([a, b])
+      // selection bottom = 100; b.y should become 40
+      expect(b.y).toBeCloseTo(40)
+      expect(a.y).toBe(0)
+    })
+  })
+
+  // --- align.centerVertical ------------------------------------------------
+
+  describe('align.centerVertical', () => {
+    it('centers objects on the vertical axis of the selection', () => {
+      const a = makeRect(0, 0, 50, 100)   // cy = 50
+      const b = makeRect(60, 200, 50, 100) // cy = 250
+      const { align } = stage as unknown as AlignPluginAPI
+      align.centerVertical([a, b])
+      // selection: y=0, height=300, cy=150
+      expect(a.y).toBeCloseTo(100)  // 150 - 50 = 100
+      expect(b.y).toBeCloseTo(100)
+    })
+  })
+
+  // --- align.distributeHorizontally ----------------------------------------
+
+  describe('distributeHorizontally', () => {
+    it('does nothing for fewer than 3 objects', () => {
+      const a = makeRect(0, 0, 50, 50)
+      const b = makeRect(200, 0, 50, 50)
+      const origBX = b.x
+      const { align } = stage as unknown as AlignPluginAPI
+      align.distributeHorizontally([a, b])
+      expect(b.x).toBe(origBX)
+    })
+
+    it('spaces 3 objects evenly along the horizontal axis', () => {
+      // a: 0..50, b: 200..250, c: 300..350
+      const a = makeRect(0, 0, 50, 50)
+      const b = makeRect(200, 0, 50, 50)
+      const c = makeRect(300, 0, 50, 50)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.distributeHorizontally([a, b, c])
+      // outer bounds: 0 to 350, total width = 150, gap = (350-150)/2 = 100
+      // b should start at 50 + 100 = 150
+      expect(b.x).toBeCloseTo(150)
+      expect(a.x).toBe(0)   // unchanged
+      expect(c.x).toBe(300) // unchanged
+    })
+
+    it('does nothing for empty array', () => {
+      expect(() => (stage as unknown as AlignPluginAPI).align.distributeHorizontally([])).not.toThrow()
+    })
+  })
+
+  // --- align.distributeVertically ------------------------------------------
+
+  describe('distributeVertically', () => {
+    it('spaces 3 objects evenly along the vertical axis', () => {
+      // a: 0..50, b: 200..250, c: 300..350
+      const a = makeRect(0, 0, 50, 50)
+      const b = makeRect(0, 200, 50, 50)
+      const c = makeRect(0, 300, 50, 50)
+      const { align } = stage as unknown as AlignPluginAPI
+      align.distributeVertically([a, b, c])
+      // outer bounds: 0 to 350, total height = 150, gap = 100
+      // b should start at 150
+      expect(b.y).toBeCloseTo(150)
+      expect(a.y).toBe(0)
+      expect(c.y).toBe(300)
+    })
+  })
+})

--- a/packages/plugins/align/tsconfig.json
+++ b/packages/plugins/align/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,24 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/align:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/connector:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
Implement @nexvas/plugin-align

**Method:** align.left / right / top / bottom
**Effect:** align edges to the anchor rect 

**Method:** align.centerHorizontal / centerVertical
**Effect:** align centers to the anchor

**Method:** align.distributeHorizontally / distributeVertically
**Effect:** Even spacing, outermost objects fixed


 All operations accept `{ relativeTo: 'selection' | 'stage' | 'first' | BaseObject }` and go through `stage.batch()` - one undo
  entry per call.