### PR TITLE
Implement clipboard plugin

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -227,6 +227,8 @@ export interface StageEventMap extends ObjectEventMap {
    * the children in their original order.
    */
   'group:dissolved': { group: Group; layer: Layer; members: BaseObject[] }
+  /** Fired by ClipboardPlugin when objects are pasted onto the stage. */
+  'clipboard:paste': { objects: BaseObject[] }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/clipboard/package.json
+++ b/packages/plugins/clipboard/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-clipboard",
+  "version": "0.0.1",
+  "description": "Copy/paste clipboard plugin for NexVas",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/clipboard/src/ClipboardPlugin.ts
+++ b/packages/plugins/clipboard/src/ClipboardPlugin.ts
@@ -1,0 +1,354 @@
+import type { Plugin, StageInterface, BaseObject, ObjectJSON } from '@nexvas/core'
+import { objectFromJSON } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PASTE_OFFSET = 20
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all IDs from a tree of ObjectJSON (including Group children). */
+function collectIds(objects: ObjectJSON[]): Set<string> {
+  const ids = new Set<string>()
+  for (const obj of objects) {
+    if (obj.id) ids.add(obj.id)
+    if (obj.type === 'Group' && Array.isArray((obj as GroupJSON).children)) {
+      for (const id of collectIds((obj as GroupJSON).children)) ids.add(id)
+    }
+  }
+  return ids
+}
+
+/** Generate a simple unique id (same pattern as BaseObject internal helper). */
+let _nextId = Date.now()
+function freshId(): string {
+  return `obj_${(_nextId++).toString(36)}`
+}
+
+interface GroupJSON extends ObjectJSON {
+  children: ObjectJSON[]
+}
+
+interface ConnectorEndRef {
+  objectId: string
+  portId: string
+}
+
+interface ConnectorJSON extends ObjectJSON {
+  sourceRef?: ConnectorEndRef
+  targetRef?: ConnectorEndRef
+}
+
+/**
+ * Deep-clone an array of ObjectJSON, assigning fresh IDs to every object
+ * that is present in `knownIds`. Connector sourceRef/targetRef are remapped
+ * when the referenced object is also in the clipped set.
+ */
+function remapIds(objects: ObjectJSON[], idMap: Map<string, string>): ObjectJSON[] {
+  return objects.map((obj) => {
+    const cloned: ObjectJSON = JSON.parse(JSON.stringify(obj)) as ObjectJSON
+    if (cloned.id && idMap.has(cloned.id)) {
+      cloned.id = idMap.get(cloned.id)!
+    }
+
+    // Remap Group children recursively
+    if (cloned.type === 'Group' && Array.isArray((cloned as GroupJSON).children)) {
+      ;(cloned as GroupJSON).children = remapIds((cloned as GroupJSON).children, idMap)
+    }
+
+    // Remap Connector refs when the target is inside the clipboard
+    if (cloned.type === 'Connector') {
+      const conn = cloned as ConnectorJSON
+      if (conn.sourceRef && idMap.has(conn.sourceRef.objectId)) {
+        conn.sourceRef = { ...conn.sourceRef, objectId: idMap.get(conn.sourceRef.objectId)! }
+      }
+      if (conn.targetRef && idMap.has(conn.targetRef.objectId)) {
+        conn.targetRef = { ...conn.targetRef, objectId: idMap.get(conn.targetRef.objectId)! }
+      }
+    }
+
+    return cloned
+  })
+}
+
+/** Build an old→new ID mapping for all objects in a snapshot. */
+function buildIdMap(objects: ObjectJSON[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const id of collectIds(objects)) {
+    map.set(id, freshId())
+  }
+  return map
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for the paste operation. */
+export interface PasteOptions {
+  /** World-space position where the top-left of the pasted selection will land. */
+  x?: number
+  y?: number
+}
+
+/** Duck-typed minimal interface for SelectionPlugin. */
+interface SelectionLike {
+  readonly selected: readonly BaseObject[]
+  select(obj: BaseObject): void
+  addToSelection(obj: BaseObject): void
+  clearSelection(): void
+}
+
+/** Type augmentation to access ClipboardPlugin API through the stage. */
+export interface ClipboardPluginAPI {
+  clipboard: ClipboardController
+}
+
+// ---------------------------------------------------------------------------
+// ClipboardController
+// ---------------------------------------------------------------------------
+
+/**
+ * Provides copy, cut, paste, and duplicate operations for canvas objects.
+ * Requires SelectionPlugin to be installed on the same stage.
+ */
+export class ClipboardController {
+  private _stage: StageInterface
+  private _snapshot: ObjectJSON[] = []
+  /** Accumulated offset for successive pastes without explicit position. */
+  private _pasteCount = 0
+
+  constructor(stage: StageInterface) {
+    this._stage = stage
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Copy selected objects to the internal clipboard.
+   * Returns the number of objects copied, or 0 if SelectionPlugin is absent.
+   */
+  copy(): number {
+    const selected = this._getSelected()
+    if (selected.length === 0) return 0
+    this._snapshot = selected.map((obj) => obj.toJSON())
+    this._pasteCount = 0
+    return selected.length
+  }
+
+  /**
+   * Cut selected objects: copy to clipboard and remove from stage.
+   * Wrapped in `stage.batch()` so HistoryPlugin records one undo entry.
+   */
+  cut(): number {
+    const selected = this._getSelected()
+    if (selected.length === 0) return 0
+    this._snapshot = selected.map((obj) => obj.toJSON())
+    this._pasteCount = 0
+    this._stage.batch(() => {
+      for (const obj of selected) {
+        const layer = this._stage.getObjectLayer(obj)
+        layer?.remove(obj)
+      }
+    })
+    this._clearSelection()
+    return selected.length
+  }
+
+  /**
+   * Paste clipboard objects onto the stage.
+   * Each call without an explicit position offsets by PASTE_OFFSET pixels.
+   * Uses `stage.batch()` — HistoryPlugin records one undo entry.
+   *
+   * @param options - Optional world-space position to place the pasted objects.
+   * @returns The newly created objects, or an empty array if clipboard is empty.
+   */
+  paste(options?: PasteOptions): BaseObject[] {
+    if (this._snapshot.length === 0) return []
+
+    this._pasteCount++
+    const idMap = buildIdMap(this._snapshot)
+    const remapped = remapIds(this._snapshot, idMap)
+
+    // Determine offset
+    let dx: number
+    let dy: number
+
+    if (options?.x !== undefined && options?.y !== undefined) {
+      // Explicit position: compute delta from the bounding-box origin of the snapshot
+      const { minX, minY } = this._snapshotBounds()
+      dx = options.x - minX
+      dy = options.y - minY
+    } else {
+      dx = PASTE_OFFSET * this._pasteCount
+      dy = PASTE_OFFSET * this._pasteCount
+    }
+
+    const layer = this._stage.layers[0]
+    if (!layer) return []
+
+    const added: BaseObject[] = []
+
+    this._stage.batch(() => {
+      for (const json of remapped) {
+        const obj = objectFromJSON(json)
+        obj.x += dx
+        obj.y += dy
+        layer.add(obj)
+        added.push(obj)
+      }
+    })
+
+    // Update selection to pasted objects
+    this._replaceSelection(added)
+    this._stage.emit('clipboard:paste', { objects: added })
+    this._stage.markDirty()
+    return added
+  }
+
+  /**
+   * Duplicate selected objects in one step (copy + paste with default offset).
+   * @returns The newly created duplicate objects.
+   */
+  duplicate(): BaseObject[] {
+    this.copy()
+    return this.paste()
+  }
+
+  /** True when the internal clipboard has content. */
+  get hasContent(): boolean {
+    return this._snapshot.length > 0
+  }
+
+  /** Number of objects currently in the clipboard snapshot. */
+  get count(): number {
+    return this._snapshot.length
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private _getSelectionPlugin(): SelectionLike | null {
+    const s = this._stage as unknown as { selection?: SelectionLike }
+    if (s.selection && typeof s.selection.selected !== 'undefined') return s.selection
+    return null
+  }
+
+  private _getSelected(): BaseObject[] {
+    const sel = this._getSelectionPlugin()
+    if (!sel) return []
+    return Array.from(sel.selected)
+  }
+
+  private _clearSelection(): void {
+    this._getSelectionPlugin()?.clearSelection()
+  }
+
+  private _replaceSelection(objects: BaseObject[]): void {
+    const sel = this._getSelectionPlugin()
+    if (!sel || objects.length === 0) return
+    sel.clearSelection()
+    for (const obj of objects) sel.addToSelection(obj)
+  }
+
+  private _snapshotBounds(): { minX: number; minY: number } {
+    let minX = Infinity
+    let minY = Infinity
+    for (const json of this._snapshot) {
+      const x = typeof json.x === 'number' ? json.x : 0
+      const y = typeof json.y === 'number' ? json.y : 0
+      if (x < minX) minX = x
+      if (y < minY) minY = y
+    }
+    return { minX: isFinite(minX) ? minX : 0, minY: isFinite(minY) ? minY : 0 }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ClipboardPlugin
+// ---------------------------------------------------------------------------
+
+/**
+ * ClipboardPlugin — copy / cut / paste / duplicate for canvas objects.
+ *
+ * Requires SelectionPlugin to be installed on the same stage.
+ * After installing, access clipboard operations via `(stage as ClipboardPluginAPI).clipboard`.
+ *
+ * Keyboard bindings:
+ * - Ctrl+C / Cmd+C — copy
+ * - Ctrl+X / Cmd+X — cut
+ * - Ctrl+V / Cmd+V — paste
+ * - Ctrl+D / Cmd+D — duplicate
+ *
+ * @example
+ * ```ts
+ * stage.use(new ClipboardPlugin())
+ * const { clipboard } = stage as unknown as ClipboardPluginAPI
+ *
+ * clipboard.copy()
+ * clipboard.paste()
+ * clipboard.paste({ x: 200, y: 150 })
+ * clipboard.duplicate()
+ * ```
+ */
+export class ClipboardPlugin implements Plugin {
+  readonly name = 'plugin-clipboard'
+  readonly version = '0.0.1'
+
+  private _controller: ClipboardController | null = null
+  private _keyHandler: ((e: KeyboardEvent) => void) | null = null
+
+  /** Install the plugin on a stage. Attaches `clipboard` to the stage and registers keyboard shortcuts. */
+  install(stage: StageInterface): void {
+    const controller = new ClipboardController(stage)
+    this._controller = controller
+    ;(stage as unknown as ClipboardPluginAPI).clipboard = controller
+
+    const handler = (e: KeyboardEvent): void => {
+      const meta = e.ctrlKey || e.metaKey
+      if (!meta) return
+
+      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
+      if (tag === 'input' || tag === 'textarea') return
+
+      switch (e.key.toLowerCase()) {
+        case 'c':
+          e.preventDefault()
+          controller.copy()
+          break
+        case 'x':
+          e.preventDefault()
+          controller.cut()
+          break
+        case 'v':
+          e.preventDefault()
+          controller.paste()
+          break
+        case 'd':
+          e.preventDefault()
+          controller.duplicate()
+          break
+      }
+    }
+
+    this._keyHandler = handler
+    document.addEventListener('keydown', handler)
+  }
+
+  /** Remove the plugin. Detaches `clipboard` from stage and removes keyboard listener. */
+  uninstall(stage: StageInterface): void {
+    if (this._keyHandler) {
+      document.removeEventListener('keydown', this._keyHandler)
+      this._keyHandler = null
+    }
+    delete (stage as unknown as Partial<ClipboardPluginAPI>).clipboard
+    this._controller = null
+  }
+}

--- a/packages/plugins/clipboard/src/index.ts
+++ b/packages/plugins/clipboard/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  ClipboardPlugin,
+  ClipboardController,
+  type ClipboardPluginAPI,
+  type PasteOptions,
+} from './ClipboardPlugin.js'

--- a/packages/plugins/clipboard/tests/ClipboardPlugin.test.ts
+++ b/packages/plugins/clipboard/tests/ClipboardPlugin.test.ts
@@ -1,0 +1,550 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ClipboardPlugin, type ClipboardPluginAPI } from '../src/ClipboardPlugin.js'
+import { Rect, Layer, BoundingBox } from '@nexvas/core'
+import type { StageInterface, Viewport, FontManager, RenderPass, BaseObject } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SelectionLike {
+  selected: readonly BaseObject[]
+  select(obj: BaseObject): void
+  addToSelection(obj: BaseObject): void
+  clearSelection(): void
+}
+
+function makeStage(selectionPlugin?: SelectionLike): {
+  stage: StageInterface
+  layer: Layer
+  emitted: Map<string, unknown[]>
+} {
+  const layer = new Layer()
+  const handlers = new Map<string, Set<(e: unknown) => void>>()
+  const passes: RenderPass[] = []
+  const emitted = new Map<string, unknown[]>()
+
+  const stage: StageInterface = {
+    id: 'test-stage',
+    canvasKit: {},
+    get layers() {
+      return [layer] as unknown as readonly Layer[]
+    },
+    viewport: { x: 0, y: 0, scale: 1, width: 800, height: 600 } as unknown as Viewport,
+    fonts: {} as unknown as FontManager,
+    on(event: string, handler: (e: unknown) => void) {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    },
+    off(event: string, handler: (e: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+    },
+    emit(event: string, data: unknown) {
+      if (!emitted.has(event)) emitted.set(event, [])
+      emitted.get(event)!.push(data)
+      handlers.get(event)?.forEach((h) => h(data))
+    },
+    addRenderPass(pass: RenderPass) {
+      passes.push(pass)
+    },
+    removeRenderPass(pass: RenderPass) {
+      const i = passes.indexOf(pass)
+      if (i !== -1) passes.splice(i, 1)
+    },
+    getBoundingBox() {
+      return new BoundingBox(0, 0, 800, 600)
+    },
+    render() {},
+    markDirty() {},
+    resize() {},
+    find: () => [],
+    findByType: () => [],
+    getObjectById: () => undefined,
+    registerObject: () => {},
+    getObjectLayer(obj: BaseObject) {
+      return layer.objects.includes(obj) ? layer : null
+    },
+    bringToFront: () => {},
+    sendToBack: () => {},
+    bringForward: () => {},
+    sendBackward: () => {},
+    groupObjects: () => {
+      throw new Error('not implemented')
+    },
+    ungroupObject: () => [],
+    batch(fn: () => void) {
+      fn()
+    },
+  } as unknown as StageInterface
+
+  if (selectionPlugin) {
+    ;(stage as unknown as { selection: SelectionLike }).selection = selectionPlugin
+  }
+
+  return { stage, layer, emitted }
+}
+
+function makeSelection(objects: BaseObject[] = []): SelectionLike & { _objects: BaseObject[] } {
+  const _objects: BaseObject[] = [...objects]
+  return {
+    _objects,
+    get selected() {
+      return _objects as readonly BaseObject[]
+    },
+    select(obj: BaseObject) {
+      _objects.length = 0
+      _objects.push(obj)
+    },
+    addToSelection(obj: BaseObject) {
+      _objects.push(obj)
+    },
+    clearSelection() {
+      _objects.length = 0
+    },
+  }
+}
+
+function makeRect(x = 0, y = 0, w = 100, h = 100): Rect {
+  return new Rect({ x, y, width: w, height: h })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClipboardPlugin', () => {
+  describe('lifecycle', () => {
+    it('installs without throwing', () => {
+      const { stage } = makeStage()
+      expect(() => new ClipboardPlugin().install(stage)).not.toThrow()
+    })
+
+    it('exposes clipboard controller after install', () => {
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage()
+      plugin.install(stage)
+      expect((stage as unknown as ClipboardPluginAPI).clipboard).toBeDefined()
+    })
+
+    it('uninstalls cleanly', () => {
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage()
+      plugin.install(stage)
+      plugin.uninstall(stage)
+      expect((stage as unknown as Partial<ClipboardPluginAPI>).clipboard).toBeUndefined()
+    })
+
+    it('install → uninstall → re-install works', () => {
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage()
+      plugin.install(stage)
+      plugin.uninstall(stage)
+      const { stage: stage2 } = makeStage()
+      plugin.install(stage2)
+      expect((stage2 as unknown as ClipboardPluginAPI).clipboard).toBeDefined()
+      plugin.uninstall(stage2)
+    })
+  })
+
+  describe('copy', () => {
+    it('returns 0 when no SelectionPlugin is installed', () => {
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage()
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      expect(ctrl.copy()).toBe(0)
+      expect(ctrl.hasContent).toBe(false)
+    })
+
+    it('returns 0 when selection is empty', () => {
+      const sel = makeSelection([])
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage(sel)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      expect(ctrl.copy()).toBe(0)
+      expect(ctrl.hasContent).toBe(false)
+    })
+
+    it('returns count of copied objects', () => {
+      const r1 = makeRect(10, 10)
+      const r2 = makeRect(50, 50)
+      const sel = makeSelection([r1, r2])
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage(sel)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      expect(ctrl.copy()).toBe(2)
+      expect(ctrl.hasContent).toBe(true)
+      expect(ctrl.count).toBe(2)
+    })
+
+    it('does not remove objects from the stage', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      expect(layer.objects).toContain(r1)
+    })
+  })
+
+  describe('paste', () => {
+    it('returns empty array when clipboard is empty', () => {
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage()
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      expect(ctrl.paste()).toEqual([])
+    })
+
+    it('adds new objects to the first layer', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const pasted = ctrl.paste()
+      expect(pasted).toHaveLength(1)
+      expect(layer.objects).toContain(pasted[0])
+    })
+
+    it('generates new IDs — pasted object has a different id than original', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const [pasted] = ctrl.paste()!
+      expect(pasted!.id).not.toBe(r1.id)
+    })
+
+    it('applies PASTE_OFFSET on first paste', () => {
+      const r1 = makeRect(100, 100)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const [pasted] = ctrl.paste()!
+      expect(pasted!.x).toBe(120) // 100 + 20
+      expect(pasted!.y).toBe(120)
+    })
+
+    it('accumulates offset with successive pastes', () => {
+      const r1 = makeRect(0, 0)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const [p1] = ctrl.paste()!
+      const [p2] = ctrl.paste()!
+      expect(p1!.x).toBe(20)
+      expect(p2!.x).toBe(40)
+    })
+
+    it('paste with explicit position places at that position', () => {
+      const r1 = makeRect(50, 50)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const [pasted] = ctrl.paste({ x: 200, y: 300 })!
+      expect(pasted!.x).toBe(200)
+      expect(pasted!.y).toBe(300)
+    })
+
+    it("emits 'clipboard:paste' event with pasted objects", () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer, emitted } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const pasted = ctrl.paste()
+      const events = emitted.get('clipboard:paste') ?? []
+      expect(events).toHaveLength(1)
+      expect((events[0] as { objects: BaseObject[] }).objects).toEqual(pasted)
+    })
+
+    it('resets selection to pasted objects', () => {
+      const r1 = makeRect(0, 0)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const pasted = ctrl.paste()
+      expect(sel._objects).toEqual(pasted)
+    })
+
+    it('preserves object properties (type, dimensions, fill)', () => {
+      const r1 = new Rect({
+        x: 10,
+        y: 20,
+        width: 80,
+        height: 60,
+        fill: { type: 'solid', color: { r: 1, g: 0, b: 0, a: 1 } },
+      })
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const [pasted] = ctrl.paste()!
+      expect(pasted).toBeInstanceOf(Rect)
+      expect(pasted!.width).toBe(80)
+      expect(pasted!.height).toBe(60)
+    })
+
+    it('original objects are not mutated by paste', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      ctrl.paste()
+      expect(r1.x).toBe(10)
+      expect(r1.y).toBe(10)
+    })
+
+    it('copy resets paste offset counter', () => {
+      const r1 = makeRect(0, 0)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      ctrl.paste() // offset 20
+      ctrl.paste() // offset 40
+      // Restore selection to r1 so the second copy snapshots x=0 again
+      sel._objects.length = 0
+      sel._objects.push(r1)
+      ctrl.copy()  // resets counter, snapshots r1 at x=0
+      const [p] = ctrl.paste()! // offset 20 again
+      expect(p!.x).toBe(20)
+    })
+  })
+
+  describe('cut', () => {
+    it('removes original objects from the stage', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.cut()
+      expect(layer.objects).not.toContain(r1)
+    })
+
+    it('stores snapshot that can be pasted', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.cut()
+      expect(ctrl.hasContent).toBe(true)
+      const pasted = ctrl.paste()
+      expect(pasted).toHaveLength(1)
+      expect(layer.objects).toContain(pasted[0])
+    })
+
+    it('returns 0 when nothing is selected', () => {
+      const sel = makeSelection([])
+      const plugin = new ClipboardPlugin()
+      const { stage } = makeStage(sel)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      expect(ctrl.cut()).toBe(0)
+    })
+  })
+
+  describe('duplicate', () => {
+    it('copies and pastes selected objects without touching clipboard state externally', () => {
+      const r1 = makeRect(0, 0)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      const duped = ctrl.duplicate()
+      expect(duped).toHaveLength(1)
+      expect(layer.objects).toContain(duped[0])
+      expect(duped[0]!.id).not.toBe(r1.id)
+    })
+
+    it('pasted duplicate is offset', () => {
+      const r1 = makeRect(50, 50)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      const [duped] = ctrl.duplicate()!
+      expect(duped!.x).toBe(70)
+      expect(duped!.y).toBe(70)
+    })
+  })
+
+  describe('multiple objects', () => {
+    it('pastes all copied objects', () => {
+      const r1 = makeRect(0, 0)
+      const r2 = makeRect(100, 100)
+      const sel = makeSelection([r1, r2])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      layer.add(r2)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const pasted = ctrl.paste()
+      expect(pasted).toHaveLength(2)
+      for (const p of pasted) expect(layer.objects).toContain(p)
+    })
+
+    it('all pasted objects have unique IDs differing from originals', () => {
+      const r1 = makeRect(0, 0)
+      const r2 = makeRect(100, 100)
+      const sel = makeSelection([r1, r2])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      layer.add(r2)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const pasted = ctrl.paste()
+      const originalIds = new Set([r1.id, r2.id])
+      for (const p of pasted) expect(originalIds.has(p.id)).toBe(false)
+      // All pasted IDs are unique
+      const pastedIds = pasted.map((p) => p.id)
+      expect(new Set(pastedIds).size).toBe(pastedIds.length)
+    })
+  })
+
+  describe('keyboard shortcuts', () => {
+    it('Ctrl+C triggers copy', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      const copySpy = vi.spyOn(ctrl, 'copy')
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }))
+      expect(copySpy).toHaveBeenCalledOnce()
+      plugin.uninstall(stage)
+    })
+
+    it('Ctrl+X triggers cut', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      const cutSpy = vi.spyOn(ctrl, 'cut')
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'x', ctrlKey: true, bubbles: true }))
+      expect(cutSpy).toHaveBeenCalledOnce()
+      plugin.uninstall(stage)
+    })
+
+    it('Ctrl+V triggers paste', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      ctrl.copy()
+      const pasteSpy = vi.spyOn(ctrl, 'paste')
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true }))
+      expect(pasteSpy).toHaveBeenCalledOnce()
+      plugin.uninstall(stage)
+    })
+
+    it('Ctrl+D triggers duplicate', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      const dupeSpy = vi.spyOn(ctrl, 'duplicate')
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, bubbles: true }))
+      expect(dupeSpy).toHaveBeenCalledOnce()
+      plugin.uninstall(stage)
+    })
+
+    it('uninstall removes keyboard listener', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      plugin.uninstall(stage)
+      const copySpy = vi.spyOn(ctrl, 'copy')
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }))
+      expect(copySpy).not.toHaveBeenCalled()
+    })
+
+    it('does not intercept shortcuts when focus is on an input', () => {
+      const r1 = makeRect(10, 10)
+      const sel = makeSelection([r1])
+      const plugin = new ClipboardPlugin()
+      const { stage, layer } = makeStage(sel)
+      layer.add(r1)
+      plugin.install(stage)
+      const ctrl = (stage as unknown as ClipboardPluginAPI).clipboard
+      const copySpy = vi.spyOn(ctrl, 'copy')
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }))
+      expect(copySpy).not.toHaveBeenCalled()
+      document.body.removeChild(input)
+      plugin.uninstall(stage)
+    })
+  })
+})

--- a/packages/plugins/clipboard/tsconfig.json
+++ b/packages/plugins/clipboard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/plugins/clipboard/vite.config.ts
+++ b/packages/plugins/clipboard/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      name: 'CanvasFwPluginClipboard',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: ['@nexvas/core'],
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+})

--- a/packages/plugins/clipboard/vitest.config.ts
+++ b/packages/plugins/clipboard/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@nexvas/plugin-clipboard',
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/clipboard:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/connector:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
 Implement `@nexvas/plugin-clipboard`                                                       
  
  New files:                                                                                                                    
  - `packages/plugins/clipboard/src/ClipboardPlugin.ts` - ClipboardController + ClipboardPlugin                                 
  - `packages/plugins/clipboard/src/index.ts`
  - `packages/plugins/clipboard/tests/ClipboardPlugin.test.ts`
  - `packages/plugins/clipboard/package.json`, `tsconfig.json`, `vite.config.ts`, `vitest.config.ts`

  Core change: `packages/core/src/types.ts` - StageEventMap gains 'clipboard:paste': { objects: BaseObject[] }

  Key behaviors:
  - `copy() / cut() / paste(options?) / duplicate()` - all on ClipboardController
  - Paste generates fresh IDs; Connector sourceRef/targetRef remapped when both endpoints are in the clipboard
  - Paste offset accumulates by 20px per successive call, resets on new `copy()`
  - `paste({ x, y })` places at explicit world position
  - Keyboard: `Ctrl/Cmd+C/X/V/D`; no-ops on <input>/<textarea> targets
  - Duck-types `SelectionPlugin` - no hard cross-plugin dependency