### PR TITLE
Perf: Matrix3x3.fromTRS() single-pass TRS factory

### DIFF
--- a/packages/core/src/math/Matrix3x3.ts
+++ b/packages/core/src/math/Matrix3x3.ts
@@ -44,6 +44,17 @@ export class Matrix3x3 {
     return new Matrix3x3(sx, 0, 0, 0, sy, 0, 0, 0, 1)
   }
 
+  /**
+   * Single-pass TRS factory: translate → rotate → scale.
+   * Equivalent to `translation(tx,ty).multiply(rotation(r)).multiply(scale(sx,sy))`
+   * but allocates only one matrix.
+   */
+  static fromTRS(tx: number, ty: number, radians: number, sx: number, sy: number): Matrix3x3 {
+    const cos = Math.cos(radians)
+    const sin = Math.sin(radians)
+    return new Matrix3x3(cos * sx, -sin * sy, tx, sin * sx, cos * sy, ty, 0, 0, 1)
+  }
+
   multiply(other: Matrix3x3): Matrix3x3 {
     const [a, b, c, d, e, f, g, h, i] = this.values
     const [j, k, l, m, n, o, p, q, r] = other.values

--- a/packages/core/src/objects/BaseObject.ts
+++ b/packages/core/src/objects/BaseObject.ts
@@ -222,9 +222,7 @@ export abstract class BaseObject {
   getLocalTransform(): Matrix3x3 {
     if (this._localTransformCache !== null) return this._localTransformCache
     const rotRad = (this.rotation * Math.PI) / 180
-    this._localTransformCache = Matrix3x3.translation(this.x, this.y)
-      .multiply(Matrix3x3.rotation(rotRad))
-      .multiply(Matrix3x3.scale(this.scaleX, this.scaleY))
+    this._localTransformCache = Matrix3x3.fromTRS(this.x, this.y, rotRad, this.scaleX, this.scaleY)
     return this._localTransformCache
   }
 

--- a/packages/core/tests/math/Matrix3x3.test.ts
+++ b/packages/core/tests/math/Matrix3x3.test.ts
@@ -73,4 +73,18 @@ describe('Matrix3x3', () => {
     const m = Matrix3x3.translation(3, 7)
     expect(m.toAffine6()).toHaveLength(6)
   })
+
+  it('fromTRS matches chained translation/rotation/scale', () => {
+    const tx = 5, ty = -3, r = Math.PI / 4, sx = 2, sy = 0.5
+    const chained = Matrix3x3.translation(tx, ty)
+      .multiply(Matrix3x3.rotation(r))
+      .multiply(Matrix3x3.scale(sx, sy))
+    const fast = Matrix3x3.fromTRS(tx, ty, r, sx, sy)
+    expect(fast.equals(chained)).toBe(true)
+  })
+
+  it('fromTRS identity params give identity matrix', () => {
+    const m = Matrix3x3.fromTRS(0, 0, 0, 1, 1)
+    expect(m.equals(Matrix3x3.IDENTITY)).toBe(true)
+  })
 })


### PR DESCRIPTION
Matrix3x3.fromTRS() implemented and updated BaseObject.getLocalTransform() 