### PR TITLE
Remove set in favor of array

### DIFF
--- a/packages/core/src/Layer.ts
+++ b/packages/core/src/Layer.ts
@@ -207,12 +207,12 @@ export class Layer {
 
     if (candidates.length === 0) return null
 
-    const candidateSet = new Set<BaseObject>(candidates.map((c: RBushItem) => c.obj))
-
     // Walk in reverse z-order (topmost first) and test only candidates.
+    // Avoids Set + map allocation on every mouse event; candidate counts from the
+    // tight spatial query are small so linear scan outperforms Set construction.
     for (let i = this._objects.length - 1; i >= 0; i--) {
       const obj = this._objects[i]!
-      if (!candidateSet.has(obj)) continue
+      if (!candidates.some((c: RBushItem) => c.obj === obj)) continue
       if (obj instanceof Group) {
         const hit = obj.hitTestChild(worldX, worldY, tolerance)
         if (hit !== null) return hit


### PR DESCRIPTION
Avoids Set + map allocation on every mouse event; candidate counts from the tight spatial query are small so linear scan outperforms Set construction.

**The reasoning:**                                                                                                                                          
                                                                                                                                                          
  The R-tree search() call at line 201–207 already narrows candidates to objects whose bounding boxes overlap a 32px-expanded query box around the cursor.
   In a typical scene that's 2–10 objects, not 1000.                                                                                                      

  For that size, building new Set(candidates.map(c => c.obj)) on every mousemove event costs more (heap alloc + hash table construction) than the naive
  candidates.some(c => c.obj === obj) linear scan.