### PR TITLE
Implement plugin-animate: tweening and animation plugin with sequence…

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -229,6 +229,10 @@ export interface StageEventMap extends ObjectEventMap {
   'group:dissolved': { group: Group; layer: Layer; members: BaseObject[] }
   /** Fired by ClipboardPlugin when objects are pasted onto the stage. */
   'clipboard:paste': { objects: BaseObject[] }
+  /** Fired by AnimatePlugin when a tween, sequence, or parallel animation completes. */
+  'animate:complete': { animation: unknown }
+  /** Fired by AnimatePlugin when a tween, sequence, or parallel animation is cancelled. */
+  'animate:cancel': { animation: unknown }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/animate/package.json
+++ b/packages/plugins/animate/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-animate",
+  "version": "0.0.1",
+  "description": "Tweening and animation plugin for NexVas",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/animate/src/AnimatePlugin.ts
+++ b/packages/plugins/animate/src/AnimatePlugin.ts
@@ -1,0 +1,503 @@
+import type { Plugin, StageInterface, BaseObject, SolidFill, ColorRGBA } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Easing
+// ---------------------------------------------------------------------------
+
+/** A function that maps a normalized time [0,1] to a progress value [0,1]. */
+export type EasingFn = (t: number) => number
+
+/** Built-in easing functions exported as a namespace. */
+export const Easing = {
+  linear: (t: number) => t,
+  easeInQuad: (t: number) => t * t,
+  easeOutQuad: (t: number) => 1 - (1 - t) * (1 - t),
+  easeInOutQuad: (t: number) => t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2,
+  easeInCubic: (t: number) => t ** 3,
+  easeOutCubic: (t: number) => 1 - (1 - t) ** 3,
+  easeInOutCubic: (t: number) => t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2,
+  easeInExpo: (t: number) => t === 0 ? 0 : 2 ** (10 * t - 10),
+  easeOutExpo: (t: number) => t === 1 ? 1 : 1 - 2 ** (-10 * t),
+  easeInOutExpo: (t: number) => {
+    if (t === 0) return 0
+    if (t === 1) return 1
+    return t < 0.5 ? 2 ** (20 * t - 10) / 2 : (2 - 2 ** (-20 * t + 10)) / 2
+  },
+  easeInBounce: (t: number) => 1 - Easing.easeOutBounce(1 - t),
+  easeOutBounce: (t: number) => {
+    const n1 = 7.5625, d1 = 2.75
+    if (t < 1 / d1) return n1 * t * t
+    if (t < 2 / d1) return n1 * (t -= 1.5 / d1) * t + 0.75
+    if (t < 2.5 / d1) return n1 * (t -= 2.25 / d1) * t + 0.9375
+    return n1 * (t -= 2.625 / d1) * t + 0.984375
+  },
+  spring: (t: number) => {
+    const c4 = (2 * Math.PI) / 3
+    return t === 0 ? 0 : t === 1 ? 1 : -(2 ** (10 * t - 10)) * Math.sin((t * 10 - 10.75) * c4)
+  },
+} as const
+
+// ---------------------------------------------------------------------------
+// Tweenable properties
+// ---------------------------------------------------------------------------
+
+/** Numeric properties on BaseObject that can be tweened directly. */
+export type NumericTweenProp = 'x' | 'y' | 'width' | 'height' | 'rotation' | 'scaleX' | 'scaleY' | 'opacity'
+
+/** Color channel keys for fill/stroke color tweening. */
+type ColorChannel = 'r' | 'g' | 'b' | 'a'
+
+/** Target state passed to `anim.tween()`. */
+export interface TweenTarget {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  rotation?: number
+  scaleX?: number
+  scaleY?: number
+  opacity?: number
+  /** Target fill color — only applies when current fill is a solid fill. */
+  fillColor?: Partial<ColorRGBA>
+  /** Target stroke color — only applies when current stroke is set. */
+  strokeColor?: Partial<ColorRGBA>
+}
+
+// ---------------------------------------------------------------------------
+// Tween
+// ---------------------------------------------------------------------------
+
+/** Options passed to `AnimateController.tween()`. */
+export interface TweenOptions {
+  /** Target property values to animate toward. */
+  to: TweenTarget
+  /** Animation duration in milliseconds. Default: 300. */
+  duration?: number
+  /** Easing function. Default: `Easing.easeInOutCubic`. */
+  easing?: EasingFn
+  /** Called on every interpolated frame. */
+  onUpdate?: () => void
+  /** Called when the tween reaches its end (or reversed to its start). */
+  onComplete?: () => void
+}
+
+type TweenState = 'idle' | 'playing' | 'paused' | 'done'
+
+interface NumericSegment {
+  prop: NumericTweenProp
+  from: number
+  to: number
+}
+
+interface ColorSegment {
+  target: 'fill' | 'stroke'
+  channel: ColorChannel
+  from: number
+  to: number
+}
+
+/**
+ * A single animation that interpolates an object's properties over time.
+ * Obtain instances via `AnimateController.tween()`.
+ */
+export class Tween {
+  private _object: BaseObject
+  private _options: Required<TweenOptions>
+  private _stage: StageInterface
+  private _state: TweenState = 'idle'
+  private _elapsed: number = 0
+  private _numericSegments: NumericSegment[] = []
+  private _colorSegments: ColorSegment[] = []
+
+  /** @internal */
+  constructor(object: BaseObject, options: TweenOptions, stage: StageInterface) {
+    this._object = object
+    this._stage = stage
+    this._options = {
+      to: options.to,
+      duration: options.duration ?? 300,
+      easing: options.easing ?? Easing.easeInOutCubic,
+      onUpdate: options.onUpdate ?? (() => {}),
+      onComplete: options.onComplete ?? (() => {}),
+    }
+  }
+
+  /** Start or resume playing the tween. */
+  play(): this {
+    if (this._state === 'done') {
+      this._elapsed = 0
+      this._state = 'idle'
+    }
+    if (this._state === 'idle') this._buildSegments()
+    this._state = 'playing'
+    return this
+  }
+
+  /** Pause the tween at the current position. Call `play()` to resume. */
+  pause(): this {
+    if (this._state === 'playing') this._state = 'paused'
+    return this
+  }
+
+  /** Reverse the tween from its current position back to the start. */
+  reverse(): this {
+    for (const seg of this._numericSegments) {
+      const tmp = seg.from; seg.from = seg.to; seg.to = tmp
+    }
+    for (const seg of this._colorSegments) {
+      const tmp = seg.from; seg.from = seg.to; seg.to = tmp
+    }
+    this._elapsed = this._options.duration - this._elapsed
+    this._state = 'playing'
+    return this
+  }
+
+  /** Stop and reset the tween to its initial state. */
+  stop(): this {
+    this._state = 'done'
+    this._elapsed = 0
+    return this
+  }
+
+  /** Whether this tween has completed. */
+  get isDone(): boolean { return this._state === 'done' }
+
+  /** @internal — called by the controller each animation frame. */
+  tick(deltaMs: number): void {
+    if (this._state !== 'playing') return
+
+    this._elapsed = Math.min(this._elapsed + deltaMs, this._options.duration)
+    const t = this._options.duration === 0
+      ? 1
+      : this._elapsed / this._options.duration
+    const progress = this._options.easing(t)
+
+    for (const seg of this._numericSegments) {
+      (this._object as unknown as Record<string, number>)[seg.prop] =
+        seg.from + (seg.to - seg.from) * progress
+    }
+
+    if (this._colorSegments.length > 0) this._applyColorSegments(progress)
+
+    this._stage.markDirty()
+    this._options.onUpdate()
+
+    if (this._elapsed >= this._options.duration) {
+      this._state = 'done'
+      this._options.onComplete()
+    }
+  }
+
+  private _buildSegments(): void {
+    this._numericSegments = []
+    this._colorSegments = []
+    const obj = this._object as unknown as Record<string, number>
+    const to = this._options.to
+
+    const numProps: NumericTweenProp[] = ['x', 'y', 'width', 'height', 'rotation', 'scaleX', 'scaleY', 'opacity']
+    for (const prop of numProps) {
+      if (to[prop] !== undefined) {
+        this._numericSegments.push({ prop, from: obj[prop] ?? 0, to: to[prop]! })
+      }
+    }
+
+    if (to.fillColor !== undefined) {
+      const fill = (this._object as unknown as { fill: unknown }).fill
+      if (fill && (fill as SolidFill).type === 'solid') {
+        const color = (fill as SolidFill).color
+        for (const ch of ['r', 'g', 'b', 'a'] as ColorChannel[]) {
+          if (to.fillColor[ch] !== undefined) {
+            this._colorSegments.push({ target: 'fill', channel: ch, from: color[ch], to: to.fillColor[ch]! })
+          }
+        }
+      }
+    }
+
+    if (to.strokeColor !== undefined) {
+      const stroke = (this._object as unknown as { stroke: unknown }).stroke
+      if (stroke) {
+        const color = (stroke as { color: ColorRGBA }).color
+        for (const ch of ['r', 'g', 'b', 'a'] as ColorChannel[]) {
+          if (to.strokeColor[ch] !== undefined) {
+            this._colorSegments.push({ target: 'stroke', channel: ch, from: color[ch], to: to.strokeColor[ch]! })
+          }
+        }
+      }
+    }
+  }
+
+  private _applyColorSegments(progress: number): void {
+    const fillUpdates: Partial<ColorRGBA> = {}
+    const strokeUpdates: Partial<ColorRGBA> = {}
+    let hasFill = false
+    let hasStroke = false
+
+    for (const seg of this._colorSegments) {
+      const value = seg.from + (seg.to - seg.from) * progress
+      if (seg.target === 'fill') { fillUpdates[seg.channel] = value; hasFill = true }
+      else { strokeUpdates[seg.channel] = value; hasStroke = true }
+    }
+
+    if (hasFill) {
+      const obj = this._object as unknown as { fill: SolidFill }
+      obj.fill = { ...obj.fill, color: { ...obj.fill.color, ...fillUpdates } }
+    }
+    if (hasStroke) {
+      const obj = this._object as unknown as { stroke: { color: ColorRGBA; [k: string]: unknown } }
+      obj.stroke = { ...obj.stroke, color: { ...obj.stroke.color, ...strokeUpdates } }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composite animations
+// ---------------------------------------------------------------------------
+
+/**
+ * A sequence that plays tweens one after another.
+ * Returned by `AnimateController.sequence()`.
+ */
+export class SequenceAnimation {
+  private _tweens: Tween[]
+  private _current: number = 0
+
+  /** @internal */
+  constructor(tweens: Tween[]) {
+    this._tweens = tweens
+  }
+
+  /** Start the sequence from the first tween. */
+  play(): this {
+    this._current = 0
+    if (this._tweens[0]) this._tweens[0].play()
+    return this
+  }
+
+  /** Stop all tweens in the sequence. */
+  stop(): this {
+    for (const t of this._tweens) t.stop()
+    this._current = 0
+    return this
+  }
+
+  /** @internal */
+  tick(deltaMs: number): void {
+    const tween = this._tweens[this._current]
+    if (!tween) return
+    tween.tick(deltaMs)
+    if (tween.isDone) {
+      this._current++
+      const next = this._tweens[this._current]
+      if (next) next.play()
+    }
+  }
+
+  /** Whether the sequence has finished all tweens. */
+  get isDone(): boolean {
+    return this._current >= this._tweens.length
+  }
+}
+
+/**
+ * A parallel animation that plays all tweens simultaneously.
+ * Returned by `AnimateController.parallel()`.
+ */
+export class ParallelAnimation {
+  private _tweens: Tween[]
+
+  /** @internal */
+  constructor(tweens: Tween[]) {
+    this._tweens = tweens
+  }
+
+  /** Start all tweens simultaneously. */
+  play(): this {
+    for (const t of this._tweens) t.play()
+    return this
+  }
+
+  /** Stop all tweens. */
+  stop(): this {
+    for (const t of this._tweens) t.stop()
+    return this
+  }
+
+  /** @internal */
+  tick(deltaMs: number): void {
+    for (const t of this._tweens) t.tick(deltaMs)
+  }
+
+  /** Whether all tweens have completed. */
+  get isDone(): boolean {
+    return this._tweens.every((t) => t.isDone)
+  }
+}
+
+type Animatable = Tween | SequenceAnimation | ParallelAnimation
+
+// ---------------------------------------------------------------------------
+// AnimateController
+// ---------------------------------------------------------------------------
+
+/**
+ * Main API surface of the AnimatePlugin. Accessed via `(stage as AnimatePluginAPI).animate`.
+ */
+export class AnimateController {
+  private _stage: StageInterface
+  private _active: Set<Animatable> = new Set()
+  private _lastTimestamp: number = 0
+  private _rafId: number | null = null
+  private _bound: (ts: number) => void
+
+  /** @internal */
+  constructor(stage: StageInterface) {
+    this._stage = stage
+    this._bound = this._loop.bind(this)
+  }
+
+  /**
+   * Create and register a tween for the given object.
+   * Call `.play()` on the returned tween to start it.
+   */
+  tween(object: BaseObject, options: TweenOptions): Tween {
+    const t = new Tween(object, options, this._stage)
+    this._active.add(t)
+    this._ensureLoop()
+    return t
+  }
+
+  /**
+   * Play a series of tweens one after another.
+   * Returns a `SequenceAnimation`; call `.play()` to start.
+   */
+  sequence(tweens: Tween[]): SequenceAnimation {
+    const seq = new SequenceAnimation(tweens)
+    for (const t of tweens) this._active.delete(t)
+    this._active.add(seq)
+    this._ensureLoop()
+    return seq
+  }
+
+  /**
+   * Play multiple tweens simultaneously.
+   * Returns a `ParallelAnimation`; call `.play()` to start.
+   */
+  parallel(tweens: Tween[]): ParallelAnimation {
+    const par = new ParallelAnimation(tweens)
+    for (const t of tweens) this._active.delete(t)
+    this._active.add(par)
+    this._ensureLoop()
+    return par
+  }
+
+  /** Stop all active animations and cancel the RAF loop. */
+  stopAll(): void {
+    for (const anim of this._active) anim.stop()
+    this._active.clear()
+    this._cancelLoop()
+  }
+
+  /** @internal — called by uninstall to tear down the loop. */
+  dispose(): void {
+    this.stopAll()
+  }
+
+  private _ensureLoop(): void {
+    if (this._rafId !== null) return
+    this._lastTimestamp = performance.now()
+    this._rafId = requestAnimationFrame(this._bound)
+  }
+
+  private _cancelLoop(): void {
+    if (this._rafId !== null) {
+      cancelAnimationFrame(this._rafId)
+      this._rafId = null
+    }
+  }
+
+  private _loop(timestamp: number): void {
+    const delta = timestamp - this._lastTimestamp
+    this._lastTimestamp = timestamp
+
+    for (const anim of this._active) {
+      anim.tick(delta)
+      if (anim.isDone) {
+        this._active.delete(anim)
+        this._stage.emit('animate:complete', { animation: anim })
+      }
+    }
+
+    if (this._active.size > 0) {
+      this._rafId = requestAnimationFrame(this._bound)
+    } else {
+      this._rafId = null
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin options & API augmentation
+// ---------------------------------------------------------------------------
+
+/** Options for AnimatePlugin constructor. */
+export interface AnimatePluginOptions {
+  // Reserved for future configuration.
+}
+
+/** Type augmentation to access AnimatePlugin API through the stage. */
+export interface AnimatePluginAPI {
+  animate: AnimateController
+}
+
+// ---------------------------------------------------------------------------
+// AnimatePlugin
+// ---------------------------------------------------------------------------
+
+/**
+ * AnimatePlugin — tweening and animation for canvas objects.
+ *
+ * After installing, access animation operations via `(stage as AnimatePluginAPI).animate`.
+ * Fires `'animate:complete'` and `'animate:cancel'` stage events.
+ *
+ * @example
+ * ```ts
+ * stage.use(new AnimatePlugin())
+ * const { animate } = stage as unknown as AnimatePluginAPI
+ *
+ * const tween = animate.tween(rect, {
+ *   to: { x: 400, y: 200, opacity: 0.5 },
+ *   duration: 600,
+ *   easing: Easing.easeInOutCubic,
+ * })
+ * tween.play()
+ *
+ * // Sequence
+ * const seq = animate.sequence([tween1, tween2])
+ * seq.play()
+ *
+ * // Parallel
+ * const par = animate.parallel([tween1, tween2])
+ * par.play()
+ * ```
+ */
+export class AnimatePlugin implements Plugin {
+  readonly name = 'plugin-animate'
+  readonly version = '0.0.1'
+
+  private _controller: AnimateController | null = null
+
+  constructor(_options: AnimatePluginOptions = {}) {}
+
+  /** Install the plugin on a stage. Attaches the `animate` controller to the stage object. */
+  install(stage: StageInterface): void {
+    this._controller = new AnimateController(stage)
+    ;(stage as unknown as AnimatePluginAPI).animate = this._controller
+  }
+
+  /** Remove the plugin. Stops all animations and detaches the `animate` controller. */
+  uninstall(stage: StageInterface): void {
+    this._controller?.dispose()
+    delete (stage as unknown as Partial<AnimatePluginAPI>).animate
+    this._controller = null
+  }
+}

--- a/packages/plugins/animate/src/index.ts
+++ b/packages/plugins/animate/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  AnimatePlugin,
+  AnimateController,
+  Tween,
+  SequenceAnimation,
+  ParallelAnimation,
+  Easing,
+  type AnimatePluginOptions,
+  type AnimatePluginAPI,
+  type TweenOptions,
+  type TweenTarget,
+  type EasingFn,
+  type NumericTweenProp,
+} from './AnimatePlugin.js'

--- a/packages/plugins/animate/tests/AnimatePlugin.test.ts
+++ b/packages/plugins/animate/tests/AnimatePlugin.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  AnimatePlugin,
+  AnimateController,
+  Tween,
+  SequenceAnimation,
+  ParallelAnimation,
+  Easing,
+  type AnimatePluginAPI,
+} from '../src/AnimatePlugin.js'
+import { Rect, Layer, BoundingBox } from '@nexvas/core'
+import type { StageInterface, Viewport, FontManager, RenderPass } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStage(): StageInterface {
+  const layer = new Layer()
+  const handlers = new Map<string, Set<(e: unknown) => void>>()
+  const passes: RenderPass[] = []
+
+  const stage: StageInterface = {
+    id: 'test-stage',
+    canvasKit: {},
+    get layers() { return [layer] as unknown as readonly Layer[] },
+    viewport: { x: 0, y: 0, scale: 1, width: 800, height: 600 } as unknown as Viewport,
+    fonts: {} as unknown as FontManager,
+    on(event: string, handler: (e: unknown) => void) {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    },
+    off(event: string, handler: (e: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+    },
+    emit(event: string, data: unknown) {
+      handlers.get(event)?.forEach((h) => h(data))
+    },
+    addRenderPass(pass: RenderPass) { passes.push(pass) },
+    removeRenderPass(pass: RenderPass) {
+      const i = passes.indexOf(pass)
+      if (i !== -1) passes.splice(i, 1)
+    },
+    getBoundingBox() { return new BoundingBox(0, 0, 800, 600) },
+    render() {},
+    markDirty: vi.fn(),
+    resize() {},
+    find: () => [],
+    findByType: () => [],
+    getObjectById: () => undefined,
+    registerObject: () => {},
+    getObjectLayer: () => null,
+    bringToFront: () => {},
+    sendToBack: () => {},
+    bringForward: () => {},
+    sendBackward: () => {},
+    groupObjects: () => { throw new Error('not implemented') },
+    ungroupObject: () => [],
+    batch(fn: () => void) { fn() },
+  } as unknown as StageInterface
+
+  return stage
+}
+
+function makeRect(x = 0, y = 0, w = 100, h = 100): Rect {
+  return new Rect({ x, y, width: w, height: h })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AnimatePlugin', () => {
+  let plugin: AnimatePlugin
+  let stage: StageInterface
+
+  beforeEach(() => {
+    plugin = new AnimatePlugin()
+    stage = makeStage()
+    plugin.install(stage)
+  })
+
+  afterEach(() => {
+    // Ensure cleanup even if a test forgets
+    try { plugin.uninstall(stage) } catch { /* already uninstalled */ }
+  })
+
+  // --- lifecycle ------------------------------------------------------------
+
+  it('installs without throwing', () => {
+    const s = makeStage()
+    expect(() => new AnimatePlugin().install(s)).not.toThrow()
+  })
+
+  it('exposes animate controller after install', () => {
+    expect((stage as unknown as AnimatePluginAPI).animate).toBeDefined()
+  })
+
+  it('uninstalls cleanly — removes animate from stage', () => {
+    plugin.uninstall(stage)
+    expect((stage as unknown as Partial<AnimatePluginAPI>).animate).toBeUndefined()
+  })
+
+  it('install → uninstall → re-install works correctly', () => {
+    plugin.uninstall(stage)
+    const s2 = makeStage()
+    expect(() => plugin.install(s2)).not.toThrow()
+    expect((s2 as unknown as AnimatePluginAPI).animate).toBeDefined()
+    plugin.uninstall(s2)
+    expect((s2 as unknown as Partial<AnimatePluginAPI>).animate).toBeUndefined()
+  })
+
+  // --- Easing ---------------------------------------------------------------
+
+  describe('Easing', () => {
+    it('linear maps t=0→0, t=1→1, t=0.5→0.5', () => {
+      expect(Easing.linear(0)).toBe(0)
+      expect(Easing.linear(1)).toBe(1)
+      expect(Easing.linear(0.5)).toBe(0.5)
+    })
+
+    it('easeInOutCubic is symmetric: f(t) + f(1-t) ≈ 1', () => {
+      const t = 0.3
+      expect(Easing.easeInOutCubic(t) + Easing.easeInOutCubic(1 - t)).toBeCloseTo(1)
+    })
+
+    it('easeOutBounce returns 1 at t=1', () => {
+      expect(Easing.easeOutBounce(1)).toBe(1)
+    })
+
+    it('spring returns 0 at t=0 and 1 at t=1', () => {
+      expect(Easing.spring(0)).toBe(0)
+      expect(Easing.spring(1)).toBe(1)
+    })
+
+    it('easeInExpo returns 0 at t=0', () => {
+      expect(Easing.easeInExpo(0)).toBe(0)
+    })
+
+    it('easeOutExpo returns 1 at t=1', () => {
+      expect(Easing.easeOutExpo(1)).toBe(1)
+    })
+  })
+
+  // --- Tween.tick -----------------------------------------------------------
+
+  describe('Tween', () => {
+    it('interpolates x toward target on tick', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      tween.play()
+      tween.tick(50)
+      expect(rect.x).toBeCloseTo(50)
+    })
+
+    it('reaches target exactly at end of duration', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 200 }, duration: 200, easing: Easing.linear })
+      tween.play()
+      tween.tick(200)
+      expect(rect.x).toBeCloseTo(200)
+      expect(tween.isDone).toBe(true)
+    })
+
+    it('calls onUpdate on each tick', () => {
+      const rect = makeRect(0)
+      const onUpdate = vi.fn()
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100, onUpdate })
+      tween.play()
+      tween.tick(50)
+      expect(onUpdate).toHaveBeenCalledOnce()
+    })
+
+    it('calls onComplete when tween ends', () => {
+      const rect = makeRect(0)
+      const onComplete = vi.fn()
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100, onComplete })
+      tween.play()
+      tween.tick(150)
+      expect(onComplete).toHaveBeenCalledOnce()
+    })
+
+    it('pause stops interpolation mid-tween', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      tween.play()
+      tween.tick(50)
+      expect(rect.x).toBeCloseTo(50)
+      tween.pause()
+      tween.tick(50)
+      expect(rect.x).toBeCloseTo(50) // no change after pause
+    })
+
+    it('stop sets isDone=true', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100 })
+      tween.play()
+      tween.tick(30)
+      tween.stop()
+      expect(tween.isDone).toBe(true)
+    })
+
+    it('does not tick when idle (not yet played)', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      tween.tick(50) // no play() call
+      expect(rect.x).toBe(0) // unchanged
+    })
+
+    it('tweens opacity', () => {
+      const rect = makeRect()
+      rect.opacity = 1
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { opacity: 0 }, duration: 100, easing: Easing.linear })
+      tween.play()
+      tween.tick(50)
+      expect(rect.opacity).toBeCloseTo(0.5)
+    })
+
+    it('tweens fill color on solid fills', () => {
+      const rect = makeRect()
+      rect.fill = { type: 'solid', color: { r: 0, g: 0, b: 0, a: 1 } }
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, {
+        to: { fillColor: { r: 1 } },
+        duration: 100,
+        easing: Easing.linear,
+      })
+      tween.play()
+      tween.tick(50)
+      const fill = rect.fill as { type: string; color: { r: number } }
+      expect(fill.color.r).toBeCloseTo(0.5)
+    })
+
+    it('calls markDirty on each frame', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100 })
+      tween.play()
+      tween.tick(20)
+      expect((stage.markDirty as ReturnType<typeof vi.fn>)).toHaveBeenCalled()
+    })
+
+    it('play after done restarts from scratch', () => {
+      const rect = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const tween = animate.tween(rect, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      tween.play()
+      tween.tick(100)
+      expect(tween.isDone).toBe(true)
+      // Reset rect and replay
+      rect.x = 0
+      tween.play()
+      tween.tick(50)
+      expect(rect.x).toBeCloseTo(50)
+    })
+  })
+
+  // --- sequence -------------------------------------------------------------
+
+  describe('sequence', () => {
+    it('plays tweens one after another', () => {
+      const r1 = makeRect(0)
+      const r2 = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const t1 = animate.tween(r1, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      const t2 = animate.tween(r2, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      const seq = animate.sequence([t1, t2])
+      seq.play()
+
+      // tick t1 to completion
+      seq.tick(100)
+      expect(r1.x).toBeCloseTo(100)
+      expect(r2.x).toBe(0) // not yet started
+
+      // tick t2
+      seq.tick(50)
+      expect(r2.x).toBeCloseTo(50)
+    })
+
+    it('isDone after all tweens complete', () => {
+      const r1 = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const t1 = animate.tween(r1, { to: { x: 100 }, duration: 100 })
+      const seq = animate.sequence([t1])
+      seq.play()
+      seq.tick(200)
+      expect(seq.isDone).toBe(true)
+    })
+
+    it('stop halts the sequence', () => {
+      const r1 = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const t1 = animate.tween(r1, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      const seq = animate.sequence([t1])
+      seq.play()
+      seq.tick(30)
+      seq.stop()
+      seq.tick(70)
+      expect(r1.x).toBeCloseTo(30) // frozen at 30
+    })
+  })
+
+  // --- parallel -------------------------------------------------------------
+
+  describe('parallel', () => {
+    it('plays all tweens simultaneously', () => {
+      const r1 = makeRect(0)
+      const r2 = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const t1 = animate.tween(r1, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+      const t2 = animate.tween(r2, { to: { y: 200 }, duration: 100, easing: Easing.linear })
+      const par = animate.parallel([t1, t2])
+      par.play()
+      par.tick(50)
+      expect(r1.x).toBeCloseTo(50)
+      expect(r2.y).toBeCloseTo(100)
+    })
+
+    it('isDone when all tweens complete', () => {
+      const r1 = makeRect(0)
+      const { animate } = stage as unknown as AnimatePluginAPI
+      const t1 = animate.tween(r1, { to: { x: 100 }, duration: 100 })
+      const par = animate.parallel([t1])
+      par.play()
+      par.tick(200)
+      expect(par.isDone).toBe(true)
+    })
+  })
+
+  // --- stopAll --------------------------------------------------------------
+
+  it('stopAll cancels all active animations', () => {
+    const r1 = makeRect(0)
+    const { animate } = stage as unknown as AnimatePluginAPI
+    const tween = animate.tween(r1, { to: { x: 100 }, duration: 100, easing: Easing.linear })
+    tween.play()
+    tween.tick(30)
+    animate.stopAll()
+    // All internal tracking should be cleared; tween is done
+    expect(tween.isDone).toBe(true)
+  })
+})

--- a/packages/plugins/animate/tsconfig.json
+++ b/packages/plugins/animate/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/plugins/animate/vite.config.ts
+++ b/packages/plugins/animate/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      name: 'CanvasFwPluginAnimate',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: ['@nexvas/core'],
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+})

--- a/packages/plugins/animate/vitest.config.ts
+++ b/packages/plugins/animate/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@nexvas/plugin-animate',
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/animate:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/clipboard:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
Implement @nexvas/plugin-animate.

**What it provides:**
  - `animate.tween(object, { to, duration, easing, onUpdate, onComplete })` - animates any numeric property (x, y, width, height, rotation, scaleX, scaleY,
  opacity) plus fillColor/strokeColor on solid fills
  - Tween control: `play(), pause(), reverse(), stop(), isDone`
  - `animate.sequence([t1, t2])` - serial playback
  - `animate.parallel([t1, t2])` - simultaneous playback
  - `animate.stopAll()` - cancel everything
  - 13 built-in easings exported as `Easing` (linear through spring)
  - RAF loop self-cancels when idle; `animate:complete / animate:cancel` stage events
