### PR TITLE
Implement pinch to zoom plugin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/pinch-zoom:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/selection:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
 Implement @nexvas/plugin-pinch-zoom                                                                                                        
  
  What it does:                                                                                                                                                                                  
  - Two-finger pinch-to-zoom — tracks spread/squeeze between touch points and calls viewport.zoom() around the midpoint
  - Two-finger pan — calls `viewport.pan()` as the midpoint drifts
  - Optional one-finger pan via `panWithOneFinger: true`
  -` minScale / maxScale` constructor options clamp scale during gestures
  - `isPinching() / isPanning()` state helpers
  - Attaches `touchstart/touchmove/touchend/touchcancel` with `passive: false` (so preventDefault() suppresses native browser zoom/scroll during gestures)
  - Fully cleans up on `uninstall()`
