### PR TITLE
Implement pinch to zoom plugin

### DIFF
--- a/packages/plugins/pinch-zoom/package.json
+++ b/packages/plugins/pinch-zoom/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-pinch-zoom",
+  "version": "0.0.1",
+  "description": "Touch pinch-to-zoom and pan plugin for NexVas",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/pinch-zoom/src/PinchZoomPlugin.ts
+++ b/packages/plugins/pinch-zoom/src/PinchZoomPlugin.ts
@@ -1,0 +1,276 @@
+import type { Plugin, StageInterface } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PinchZoomPluginOptions {
+  /**
+   * Minimum scale the viewport is allowed to reach via pinch.
+   * When set, overrides the viewport's own minScale during pinch gestures.
+   * Default: uses viewport's current minScale.
+   */
+  minScale?: number
+  /**
+   * Maximum scale the viewport is allowed to reach via pinch.
+   * Default: uses viewport's current maxScale.
+   */
+  maxScale?: number
+  /**
+   * Allow single-finger panning.
+   * Default: false (single finger does nothing — left to other plugins or native scroll).
+   */
+  panWithOneFinger?: boolean
+}
+
+/** Narrowest cast we need from Stage — canvas is not on StageInterface. */
+interface StageWithCanvas extends StageInterface {
+  readonly canvas: HTMLCanvasElement
+}
+
+interface ActivePinch {
+  /** IDs of the two touch points, in order of arrival. */
+  id0: number
+  id1: number
+  /** Midpoint in canvas CSS pixels when the pinch started. */
+  midX: number
+  midY: number
+  /** Distance between the two touch points when the pinch started. */
+  startDist: number
+  /** Scale at the beginning of this pinch gesture. */
+  startScale: number
+  /** Viewport pan at the beginning of this pinch gesture. */
+  startPanX: number
+  startPanY: number
+}
+
+interface ActivePan {
+  id: number
+  lastX: number
+  lastY: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function dist(t0: Touch, t1: Touch): number {
+  const dx = t1.clientX - t0.clientX
+  const dy = t1.clientY - t0.clientY
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+function mid(t0: Touch, t1: Touch): { x: number; y: number } {
+  return { x: (t0.clientX + t1.clientX) / 2, y: (t0.clientY + t1.clientY) / 2 }
+}
+
+/** Convert a client-space point to canvas CSS-pixel space. */
+function clientToCanvas(
+  clientX: number,
+  clientY: number,
+  rect: DOMRect,
+): { x: number; y: number } {
+  return { x: clientX - rect.left, y: clientY - rect.top }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * PinchZoomPlugin — two-finger pinch-to-zoom and two-finger pan on touch devices.
+ *
+ * Listens to native `touchstart`, `touchmove`, and `touchend` events on the
+ * stage's canvas element. Calls `stage.viewport.zoom()` and `stage.viewport.pan()`
+ * so all other plugins see a consistent viewport state.
+ *
+ * @example
+ * ```ts
+ * stage.use(new PinchZoomPlugin())
+ * // or with options:
+ * stage.use(new PinchZoomPlugin({ panWithOneFinger: true }))
+ * ```
+ */
+export class PinchZoomPlugin implements Plugin {
+  readonly name = 'pinch-zoom'
+  readonly version = '0.1.0'
+
+  private _options: Required<PinchZoomPluginOptions>
+  private _stage: StageWithCanvas | null = null
+  private _pinch: ActivePinch | null = null
+  private _pan: ActivePan | null = null
+
+  private _onTouchStart: (e: TouchEvent) => void
+  private _onTouchMove: (e: TouchEvent) => void
+  private _onTouchEnd: (e: TouchEvent) => void
+
+  constructor(options: PinchZoomPluginOptions = {}) {
+    this._options = {
+      minScale: options.minScale ?? 0,
+      maxScale: options.maxScale ?? 0,
+      panWithOneFinger: options.panWithOneFinger ?? false,
+    }
+
+    this._onTouchStart = this._handleTouchStart.bind(this)
+    this._onTouchMove = this._handleTouchMove.bind(this)
+    this._onTouchEnd = this._handleTouchEnd.bind(this)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plugin lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Attach touch listeners to the stage canvas.
+   * `passive: false` is required so we can call `preventDefault()` to suppress
+   * native scroll/zoom during the gesture.
+   */
+  install(stage: StageInterface): void {
+    this._stage = stage as StageWithCanvas
+    const canvas = this._stage.canvas
+    canvas.addEventListener('touchstart', this._onTouchStart, { passive: false })
+    canvas.addEventListener('touchmove', this._onTouchMove, { passive: false })
+    canvas.addEventListener('touchend', this._onTouchEnd)
+    canvas.addEventListener('touchcancel', this._onTouchEnd)
+  }
+
+  /** Remove all touch listeners and reset gesture state. */
+  uninstall(_stage: StageInterface): void {
+    const canvas = this._stage?.canvas
+    if (canvas) {
+      canvas.removeEventListener('touchstart', this._onTouchStart)
+      canvas.removeEventListener('touchmove', this._onTouchMove)
+      canvas.removeEventListener('touchend', this._onTouchEnd)
+      canvas.removeEventListener('touchcancel', this._onTouchEnd)
+    }
+    this._pinch = null
+    this._pan = null
+    this._stage = null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Touch handlers
+  // ---------------------------------------------------------------------------
+
+  private _handleTouchStart(e: TouchEvent): void {
+    if (!this._stage) return
+
+    const touches = e.touches
+
+    if (touches.length === 2) {
+      // Start or switch to pinch mode — cancel any one-finger pan.
+      this._pan = null
+      e.preventDefault()
+
+      const t0 = touches[0]!
+      const t1 = touches[1]!
+      const vp = this._stage.viewport
+      const vpState = vp.getState()
+      const rect = this._stage.canvas.getBoundingClientRect()
+      const m = mid(t0, t1)
+      const canvasMid = clientToCanvas(m.x, m.y, rect)
+
+      this._pinch = {
+        id0: t0.identifier,
+        id1: t1.identifier,
+        midX: canvasMid.x,
+        midY: canvasMid.y,
+        startDist: dist(t0, t1),
+        startScale: vpState.scale,
+        startPanX: vpState.x,
+        startPanY: vpState.y,
+      }
+    } else if (touches.length === 1 && this._options.panWithOneFinger && !this._pinch) {
+      const t = touches[0]!
+      this._pan = { id: t.identifier, lastX: t.clientX, lastY: t.clientY }
+      e.preventDefault()
+    }
+  }
+
+  private _handleTouchMove(e: TouchEvent): void {
+    if (!this._stage) return
+
+    const touches = e.touches
+
+    if (this._pinch && touches.length >= 2) {
+      e.preventDefault()
+
+      // Find the two original touch points by identifier.
+      const t0 = this._findTouch(touches, this._pinch.id0)
+      const t1 = this._findTouch(touches, this._pinch.id1)
+      if (!t0 || !t1) return
+
+      const vp = this._stage.viewport
+      const currentDist = dist(t0, t1)
+      const scaleFactor = currentDist / this._pinch.startDist
+
+      const rect = this._stage.canvas.getBoundingClientRect()
+      const m = mid(t0, t1)
+      const canvasMid = clientToCanvas(m.x, m.y, rect)
+
+      // Compute target scale clamped to plugin options (fallback to viewport limits).
+      const vpState = vp.getState()
+      const minS = this._options.minScale > 0 ? this._options.minScale : (vp as unknown as { minScale: number }).minScale ?? 0.01
+      const maxS = this._options.maxScale > 0 ? this._options.maxScale : (vp as unknown as { maxScale: number }).maxScale ?? 64
+      const targetScale = Math.min(maxS, Math.max(minS, this._pinch.startScale * scaleFactor))
+      const actualFactor = targetScale / vpState.scale
+
+      // Zoom around the current midpoint.
+      vp.zoom(actualFactor, canvasMid.x, canvasMid.y)
+
+      // Pan by the delta in the midpoint position.
+      const midDx = canvasMid.x - this._pinch.midX
+      const midDy = canvasMid.y - this._pinch.midY
+      if (midDx !== 0 || midDy !== 0) {
+        vp.pan(midDx, midDy)
+        this._pinch.midX = canvasMid.x
+        this._pinch.midY = canvasMid.y
+      }
+    } else if (this._pan && touches.length === 1) {
+      e.preventDefault()
+      const t = this._findTouch(touches, this._pan.id)
+      if (!t) return
+
+      const dx = t.clientX - this._pan.lastX
+      const dy = t.clientY - this._pan.lastY
+      this._stage.viewport.pan(dx, dy)
+      this._pan.lastX = t.clientX
+      this._pan.lastY = t.clientY
+    }
+  }
+
+  private _handleTouchEnd(e: TouchEvent): void {
+    if (!this._stage) return
+
+    const touches = e.touches
+
+    if (this._pinch && touches.length < 2) {
+      this._pinch = null
+    }
+
+    if (this._pan && touches.length === 0) {
+      this._pan = null
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private _findTouch(list: TouchList, id: number): Touch | null {
+    for (let i = 0; i < list.length; i++) {
+      if (list[i]!.identifier === id) return list[i]!
+    }
+    return null
+  }
+
+  /** Returns true if a pinch gesture is currently in progress. */
+  isPinching(): boolean {
+    return this._pinch !== null
+  }
+
+  /** Returns true if a one-finger pan gesture is currently in progress. */
+  isPanning(): boolean {
+    return this._pan !== null
+  }
+}

--- a/packages/plugins/pinch-zoom/src/index.ts
+++ b/packages/plugins/pinch-zoom/src/index.ts
@@ -1,0 +1,2 @@
+export { PinchZoomPlugin } from './PinchZoomPlugin.js'
+export type { PinchZoomPluginOptions } from './PinchZoomPlugin.js'

--- a/packages/plugins/pinch-zoom/tests/PinchZoomPlugin.test.ts
+++ b/packages/plugins/pinch-zoom/tests/PinchZoomPlugin.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { PinchZoomPlugin } from '../src/PinchZoomPlugin.js'
+import { Layer, BoundingBox } from '@nexvas/core'
+import type { StageInterface, Viewport, FontManager, RenderPass } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal Viewport stub tracking pan/zoom calls. */
+function makeViewport(initialScale = 1): Viewport & {
+  _x: number; _y: number; _scale: number
+  minScale: number; maxScale: number
+} {
+  const vp = {
+    _x: 0,
+    _y: 0,
+    _scale: initialScale,
+    minScale: 0.01,
+    maxScale: 64,
+    getState() { return { x: vp._x, y: vp._y, scale: vp._scale, width: 800, height: 600 } },
+    pan(dx: number, dy: number) { vp._x += dx; vp._y += dy },
+    panTo(x: number, y: number) { vp._x = x; vp._y = y },
+    zoom(factor: number, _ox: number, _oy: number) {
+      vp._scale = Math.min(vp.maxScale, Math.max(vp.minScale, vp._scale * factor))
+    },
+    setScale(scale: number, ox?: number, oy?: number) { vp.zoom(scale / vp._scale, ox ?? 400, oy ?? 300) },
+    reset() { vp._x = 0; vp._y = 0; vp._scale = 1 },
+    setState(s: { x?: number; y?: number; scale?: number }) {
+      if (s.x !== undefined) vp._x = s.x
+      if (s.y !== undefined) vp._y = s.y
+      if (s.scale !== undefined) vp._scale = s.scale
+    },
+    setOptions(o: { minScale?: number; maxScale?: number }) {
+      if (o.minScale !== undefined) vp.minScale = o.minScale
+      if (o.maxScale !== undefined) vp.maxScale = o.maxScale
+    },
+    setOnChange() {},
+    setSize() {},
+    fitToRect() {},
+    animateTo() {},
+    cancelAnimation() {},
+  }
+  vi.spyOn(vp, 'zoom')
+  vi.spyOn(vp, 'pan')
+  return vp as unknown as Viewport & { _x: number; _y: number; _scale: number; minScale: number; maxScale: number }
+}
+
+/** Minimal canvas stub with event listener tracking. */
+function makeCanvas() {
+  const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>()
+  const canvas = {
+    getBoundingClientRect: () => ({ left: 0, top: 0, right: 800, bottom: 600, width: 800, height: 600 } as DOMRect),
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, _opts?: unknown) {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type)!.add(listener)
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      listeners.get(type)?.delete(listener)
+    },
+    _dispatch(type: string, event: Event) {
+      listeners.get(type)?.forEach((l) => {
+        if (typeof l === 'function') l(event)
+        else l.handleEvent(event)
+      })
+    },
+    _listenerCount(type: string) { return listeners.get(type)?.size ?? 0 },
+  }
+  return canvas
+}
+
+function makeStage(viewport?: ReturnType<typeof makeViewport>) {
+  const layer = new Layer()
+  const handlers = new Map<string, Set<(e: unknown) => void>>()
+  const passes: RenderPass[] = []
+  const vp = viewport ?? makeViewport()
+  const canvas = makeCanvas()
+
+  const stage = {
+    id: 'test-stage',
+    canvasKit: {},
+    canvas,
+    get layers() { return [layer] as unknown as readonly Layer[] },
+    viewport: vp,
+    fonts: {} as unknown as FontManager,
+    on(event: string, handler: (e: unknown) => void) {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    },
+    off(event: string, handler: (e: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+    },
+    emit(event: string, data: unknown) {
+      handlers.get(event)?.forEach((h) => h(data))
+    },
+    addRenderPass(pass: RenderPass) { passes.push(pass) },
+    removeRenderPass(pass: RenderPass) {
+      const i = passes.indexOf(pass)
+      if (i !== -1) passes.splice(i, 1)
+    },
+    getBoundingBox() { return new BoundingBox(0, 0, 800, 600) },
+    render() {},
+    markDirty: vi.fn(),
+    resize() {},
+    find: () => [],
+    findByType: () => [],
+    getObjectById: () => undefined,
+    registerObject: () => {},
+    getObjectLayer: () => null,
+    bringToFront: () => {},
+    sendToBack: () => {},
+    bringForward: () => {},
+    sendBackward: () => {},
+    groupObjects: () => { throw new Error('not implemented') },
+    ungroupObject: () => [],
+    batch(fn: () => void) { fn() },
+  } as unknown as StageInterface & { canvas: ReturnType<typeof makeCanvas>; viewport: ReturnType<typeof makeViewport> }
+
+  return { stage, vp, canvas }
+}
+
+/** Build a minimal synthetic TouchEvent. */
+function makeTouchEvent(
+  type: string,
+  touches: Array<{ id: number; clientX: number; clientY: number }>,
+): TouchEvent & { _prevented: boolean } {
+  const touchList = touches.map((t) =>
+    ({ identifier: t.id, clientX: t.clientX, clientY: t.clientY } as unknown as Touch),
+  )
+  const tl = Object.assign(touchList, {
+    length: touchList.length,
+    item: (i: number) => touchList[i] ?? null,
+  }) as unknown as TouchList
+
+  let _prevented = false
+  const event = {
+    type,
+    touches: tl,
+    preventDefault: () => { _prevented = true },
+    _prevented,
+  } as unknown as TouchEvent & { _prevented: boolean }
+
+  // Keep _prevented in sync via Object.defineProperty
+  Object.defineProperty(event, '_prevented', {
+    get: () => _prevented,
+    set: (v: boolean) => { _prevented = v },
+  })
+  ;(event as unknown as { preventDefault: () => void }).preventDefault = () => { _prevented = true }
+
+  return event
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PinchZoomPlugin', () => {
+  let plugin: PinchZoomPlugin
+  let stage: ReturnType<typeof makeStage>['stage']
+  let vp: ReturnType<typeof makeViewport>
+  let canvas: ReturnType<typeof makeCanvas>
+
+  beforeEach(() => {
+    plugin = new PinchZoomPlugin()
+    const s = makeStage()
+    stage = s.stage
+    vp = s.vp
+    canvas = s.canvas
+  })
+
+  afterEach(() => {
+    plugin.uninstall(stage)
+  })
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  it('installs without throwing', () => {
+    expect(() => plugin.install(stage)).not.toThrow()
+  })
+
+  it('attaches touch listeners on install', () => {
+    plugin.install(stage)
+    expect(canvas._listenerCount('touchstart')).toBe(1)
+    expect(canvas._listenerCount('touchmove')).toBe(1)
+    expect(canvas._listenerCount('touchend')).toBe(1)
+    expect(canvas._listenerCount('touchcancel')).toBe(1)
+  })
+
+  it('removes all listeners on uninstall', () => {
+    plugin.install(stage)
+    plugin.uninstall(stage)
+    expect(canvas._listenerCount('touchstart')).toBe(0)
+    expect(canvas._listenerCount('touchmove')).toBe(0)
+    expect(canvas._listenerCount('touchend')).toBe(0)
+    expect(canvas._listenerCount('touchcancel')).toBe(0)
+  })
+
+  it('install → uninstall → re-install works correctly', () => {
+    plugin.install(stage)
+    plugin.uninstall(stage)
+    plugin.install(stage)
+    expect(canvas._listenerCount('touchstart')).toBe(1)
+    expect(canvas._listenerCount('touchmove')).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // Pinch to zoom
+  // -------------------------------------------------------------------------
+
+  it('calls viewport.zoom() during a two-finger pinch', () => {
+    plugin.install(stage)
+
+    // Start with two fingers 100px apart.
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 350, clientY: 300 },
+      { id: 1, clientX: 450, clientY: 300 },
+    ]))
+
+    // Move fingers to 200px apart — 2× scale.
+    canvas._dispatch('touchmove', makeTouchEvent('touchmove', [
+      { id: 0, clientX: 300, clientY: 300 },
+      { id: 1, clientX: 500, clientY: 300 },
+    ]))
+
+    expect(vp.zoom).toHaveBeenCalled()
+    expect(vp._scale).toBeCloseTo(2, 1)
+  })
+
+  it('does not call viewport.zoom() with a single touch', () => {
+    plugin.install(stage)
+
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 400, clientY: 300 },
+    ]))
+    canvas._dispatch('touchmove', makeTouchEvent('touchmove', [
+      { id: 0, clientX: 420, clientY: 300 },
+    ]))
+
+    expect(vp.zoom).not.toHaveBeenCalled()
+  })
+
+  it('resets pinch state when fingers lift', () => {
+    plugin.install(stage)
+
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 350, clientY: 300 },
+      { id: 1, clientX: 450, clientY: 300 },
+    ]))
+
+    expect(plugin.isPinching()).toBe(true)
+
+    canvas._dispatch('touchend', makeTouchEvent('touchend', []))
+    expect(plugin.isPinching()).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // Two-finger pan
+  // -------------------------------------------------------------------------
+
+  it('pans the viewport when two-finger midpoint moves', () => {
+    plugin.install(stage)
+
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 300, clientY: 300 },
+      { id: 1, clientX: 500, clientY: 300 },
+    ]))
+
+    // Move both fingers 50px to the right without changing distance.
+    canvas._dispatch('touchmove', makeTouchEvent('touchmove', [
+      { id: 0, clientX: 350, clientY: 300 },
+      { id: 1, clientX: 550, clientY: 300 },
+    ]))
+
+    expect(vp.pan).toHaveBeenCalled()
+    expect(vp._x).toBeCloseTo(50, 0)
+  })
+
+  // -------------------------------------------------------------------------
+  // One-finger pan (opt-in)
+  // -------------------------------------------------------------------------
+
+  it('does not pan with one finger when panWithOneFinger is false (default)', () => {
+    plugin.install(stage)
+
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 400, clientY: 300 },
+    ]))
+    canvas._dispatch('touchmove', makeTouchEvent('touchmove', [
+      { id: 0, clientX: 450, clientY: 300 },
+    ]))
+
+    expect(vp.pan).not.toHaveBeenCalled()
+  })
+
+  it('pans with one finger when panWithOneFinger: true', () => {
+    plugin.uninstall(stage)
+    plugin = new PinchZoomPlugin({ panWithOneFinger: true })
+    plugin.install(stage)
+
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 400, clientY: 300 },
+    ]))
+    canvas._dispatch('touchmove', makeTouchEvent('touchmove', [
+      { id: 0, clientX: 450, clientY: 300 },
+    ]))
+
+    expect(vp.pan).toHaveBeenCalled()
+    expect(vp._x).toBeCloseTo(50, 0)
+  })
+
+  // -------------------------------------------------------------------------
+  // Scale clamping
+  // -------------------------------------------------------------------------
+
+  it('respects maxScale option', () => {
+    plugin.uninstall(stage)
+    plugin = new PinchZoomPlugin({ maxScale: 1.5 })
+    const s = makeStage()
+    stage = s.stage
+    vp = s.vp
+    canvas = s.canvas
+    plugin.install(stage)
+
+    // Spread fingers very far apart — would produce 4× zoom without clamp.
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 390, clientY: 300 },
+      { id: 1, clientX: 410, clientY: 300 },
+    ]))
+    canvas._dispatch('touchmove', makeTouchEvent('touchmove', [
+      { id: 0, clientX: 200, clientY: 300 },
+      { id: 1, clientX: 600, clientY: 300 },
+    ]))
+
+    expect(vp._scale).toBeLessThanOrEqual(1.5 + 0.01)
+  })
+
+  // -------------------------------------------------------------------------
+  // State helpers
+  // -------------------------------------------------------------------------
+
+  it('isPinching() returns false before any gesture', () => {
+    plugin.install(stage)
+    expect(plugin.isPinching()).toBe(false)
+  })
+
+  it('isPanning() returns false with default options', () => {
+    plugin.install(stage)
+    canvas._dispatch('touchstart', makeTouchEvent('touchstart', [
+      { id: 0, clientX: 400, clientY: 300 },
+    ]))
+    expect(plugin.isPanning()).toBe(false)
+  })
+})

--- a/packages/plugins/pinch-zoom/tsconfig.json
+++ b/packages/plugins/pinch-zoom/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/plugins/pinch-zoom/vite.config.ts
+++ b/packages/plugins/pinch-zoom/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      name: 'CanvasFwPluginPinchZoom',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: ['@nexvas/core'],
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+})

--- a/packages/plugins/pinch-zoom/vitest.config.ts
+++ b/packages/plugins/pinch-zoom/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@nexvas/plugin-pinch-zoom',
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/pinch-zoom:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/selection:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
 Implement **@nexvas/plugin-pinch-zoom**                                                                                                   
  
  What it does:                                                                                                                                                                                  
  - Two-finger pinch-to-zoom — tracks spread/squeeze between touch points and calls viewport.zoom() around the midpoint
  - Two-finger pan — calls `viewport.pan()` as the midpoint drifts
  - Optional one-finger pan via `panWithOneFinger: true`
  -` minScale / maxScale` constructor options clamp scale during gestures
  - `isPinching() / isPanning()` state helpers
  - Attaches `touchstart/touchmove/touchend/touchcancel` with `passive: false` (so preventDefault() suppresses native browser zoom/scroll during gestures)
  - Fully cleans up on `uninstall()`
