### PR TITLE
Implement ruler plugin: horizontal + vertical canvas rulers with pan/…

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -233,6 +233,12 @@ export interface StageEventMap extends ObjectEventMap {
   'animate:complete': { animation: unknown }
   /** Fired by AnimatePlugin when a tween, sequence, or parallel animation is cancelled. */
   'animate:cancel': { animation: unknown }
+  /**
+   * Fired by RulerPlugin immediately after install.
+   * `size` is the ruler band thickness in CSS pixels — the app should inset
+   * the canvas element by this amount on the top and left edges.
+   */
+  'ruler:ready': { size: number }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/ruler/package.json
+++ b/packages/plugins/ruler/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-ruler",
+  "version": "0.0.1",
+  "description": "Canvas ruler plugin for NexVas — horizontal and vertical rulers with pan/zoom tracking",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/ruler/src/RulerPlugin.ts
+++ b/packages/plugins/ruler/src/RulerPlugin.ts
@@ -1,0 +1,292 @@
+import type { Plugin, StageInterface, RenderContext, RenderPass } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// CanvasKit interface fragments
+// ---------------------------------------------------------------------------
+
+interface SkCanvas {
+  drawRect(rect: Float32Array | number[], paint: unknown): void
+  drawLine(x0: number, y0: number, x1: number, y1: number, paint: unknown): void
+  drawText(str: string, x: number, y: number, paint: unknown, font: unknown): void
+  save(): number
+  restore(): void
+  concat(matr: number[]): void
+}
+
+interface RulerCK {
+  Paint: new () => SkPaint
+  Font: new (face: unknown | null, size: number) => SkFont
+  Color4f(r: number, g: number, b: number, a: number): Float32Array
+  PaintStyle: { Fill: unknown; Stroke: unknown }
+}
+
+interface SkPaint {
+  setStyle(style: unknown): void
+  setColor(color: Float32Array): void
+  setAntiAlias(aa: boolean): void
+  setStrokeWidth(w: number): void
+  delete(): void
+}
+
+interface SkFont {
+  delete(): void
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RulerColor {
+  r: number
+  g: number
+  b: number
+  a: number
+}
+
+export interface RulerPluginOptions {
+  /** Ruler band thickness in CSS pixels. Default: 20. */
+  size?: number
+  /** Display unit for tick labels. Default: 'px'. */
+  unit?: 'px' | 'pt' | 'mm' | 'cm' | 'in'
+  /** Tick mark and border color. Default: mid-grey. */
+  tickColor?: RulerColor
+  /** Ruler band background color. Default: near-white. */
+  backgroundColor?: RulerColor
+  /** Tick label text color. Default: dark grey. */
+  textColor?: RulerColor
+  /** Label font size in screen pixels. Default: 9. */
+  fontSize?: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** World pixels per display unit at 96 DPI. */
+const UNIT_SCALE: Record<string, number> = {
+  px: 1,
+  pt: 96 / 72,       // 1 pt = 1.333… px
+  mm: 96 / 25.4,     // 1 mm = 3.779… px
+  cm: 96 / 2.54,     // 1 cm = 37.79… px
+  in: 96,            // 1 in = 96 px
+}
+
+/** Round to a "nice" tick interval: 1, 2, 5, 10, 20, 50, 100 … */
+function niceInterval(raw: number): number {
+  if (raw <= 0) return 1
+  const magnitude = Math.pow(10, Math.floor(Math.log10(raw)))
+  const fraction = raw / magnitude
+  if (fraction < 1.5) return magnitude
+  if (fraction < 3.5) return magnitude * 2
+  if (fraction < 7.5) return magnitude * 5
+  return magnitude * 10
+}
+
+/** Format a display-unit value as a compact string. */
+function formatLabel(displayValue: number): string {
+  const rounded = Math.round(displayValue * 100) / 100
+  if (rounded === Math.floor(rounded)) return String(Math.floor(rounded))
+  return rounded.toFixed(2).replace(/\.?0+$/, '')
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * RulerPlugin — draws horizontal and vertical rulers along the top and left
+ * edges of the canvas. Ticks and labels update automatically as the viewport
+ * pans and zooms.
+ *
+ * Fires `'ruler:ready'` on the stage immediately after install so the
+ * application can inset the canvas element to reveal the ruler bands.
+ *
+ * @example
+ * ```ts
+ * stage.use(new RulerPlugin({ size: 20, unit: 'px' }))
+ * stage.on('ruler:ready', ({ size }) => {
+ *   canvas.style.cssText = `position:absolute;inset:${size}px 0 0 ${size}px`
+ * })
+ * ```
+ */
+export class RulerPlugin implements Plugin {
+  readonly name = 'ruler'
+  readonly version = '0.1.0'
+
+  private _options: Required<RulerPluginOptions>
+  private _renderPass: RenderPass | null = null
+
+  constructor(options: RulerPluginOptions = {}) {
+    this._options = {
+      size: options.size ?? 20,
+      unit: options.unit ?? 'px',
+      tickColor: options.tickColor ?? { r: 0.4, g: 0.4, b: 0.4, a: 1 },
+      backgroundColor: options.backgroundColor ?? { r: 0.95, g: 0.95, b: 0.95, a: 1 },
+      textColor: options.textColor ?? { r: 0.3, g: 0.3, b: 0.3, a: 1 },
+      fontSize: options.fontSize ?? 9,
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plugin lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register the ruler render pass and emit `'ruler:ready'` with the ruler
+   * band size so the application can adjust the canvas element position.
+   */
+  install(stage: StageInterface): void {
+    this._renderPass = {
+      phase: 'post',
+      order: 1000,
+      render: (ctx: RenderContext) => this._draw(ctx),
+    }
+    stage.addRenderPass(this._renderPass)
+    stage.emit('ruler:ready', { size: this._options.size })
+  }
+
+  /** Remove the render pass, leaving no side effects on the stage. */
+  uninstall(stage: StageInterface): void {
+    if (this._renderPass) {
+      stage.removeRenderPass(this._renderPass)
+      this._renderPass = null
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+
+  private _draw(ctx: RenderContext): void {
+    if (!ctx.skCanvas || !ctx.canvasKit) return
+    const ck = ctx.canvasKit as unknown as RulerCK
+    const canvas = ctx.skCanvas as SkCanvas
+    const vp = ctx.viewport
+    const { size, unit, tickColor, backgroundColor, textColor, fontSize } = this._options
+
+    const scale = vp.scale
+    const invScale = 1 / scale
+    const unitScale = UNIT_SCALE[unit] ?? 1
+
+    // World-space extents of the visible area
+    const worldLeft = -vp.x * invScale
+    const worldTop = -vp.y * invScale
+    const worldRight = worldLeft + vp.width * invScale
+    const worldBottom = worldTop + vp.height * invScale
+
+    // Ruler band thickness and font size in world units
+    const rulerThick = size * invScale
+    const fontSizeW = fontSize * invScale
+
+    // ─── Paints ────────────────────────────────────────────────────────────
+
+    const bgPaint = new ck.Paint()
+    bgPaint.setStyle(ck.PaintStyle.Fill)
+    bgPaint.setColor(ck.Color4f(backgroundColor.r, backgroundColor.g, backgroundColor.b, backgroundColor.a))
+    bgPaint.setAntiAlias(false)
+
+    const borderPaint = new ck.Paint()
+    borderPaint.setStyle(ck.PaintStyle.Stroke)
+    borderPaint.setColor(ck.Color4f(tickColor.r, tickColor.g, tickColor.b, tickColor.a * 0.4))
+    borderPaint.setStrokeWidth(invScale)
+    borderPaint.setAntiAlias(false)
+
+    const tickPaint = new ck.Paint()
+    tickPaint.setStyle(ck.PaintStyle.Stroke)
+    tickPaint.setColor(ck.Color4f(tickColor.r, tickColor.g, tickColor.b, tickColor.a))
+    tickPaint.setStrokeWidth(invScale)
+    tickPaint.setAntiAlias(true)
+
+    const textPaint = new ck.Paint()
+    textPaint.setStyle(ck.PaintStyle.Fill)
+    textPaint.setColor(ck.Color4f(textColor.r, textColor.g, textColor.b, textColor.a))
+    textPaint.setAntiAlias(true)
+
+    // Font size in world units — the viewport scale produces correct screen size
+    const font = new ck.Font(null, fontSizeW)
+
+    // ─── Background bands ──────────────────────────────────────────────────
+
+    // Horizontal ruler (top band, full width)
+    canvas.drawRect([worldLeft, worldTop, worldRight, worldTop + rulerThick], bgPaint)
+    // Vertical ruler (left band, full height)
+    canvas.drawRect([worldLeft, worldTop, worldLeft + rulerThick, worldBottom], bgPaint)
+
+    // Separator lines
+    canvas.drawLine(worldLeft, worldTop + rulerThick, worldRight, worldTop + rulerThick, borderPaint)
+    canvas.drawLine(worldLeft + rulerThick, worldTop, worldLeft + rulerThick, worldBottom, borderPaint)
+
+    // ─── Tick interval ─────────────────────────────────────────────────────
+
+    // Target ~60 screen px between major ticks, expressed in display units
+    const rawDisplaySpacing = (60 * invScale) / unitScale
+    const majorDisplayInterval = niceInterval(rawDisplaySpacing)
+    const majorWorldInterval = majorDisplayInterval * unitScale
+
+    // 5 sub-divisions between major ticks
+    const SUB = 5
+    const minorWorldInterval = majorWorldInterval / SUB
+
+    // ─── Horizontal ruler ticks ────────────────────────────────────────────
+
+    const hContentLeft = worldLeft + rulerThick
+    const hFirstMinor = Math.ceil(hContentLeft / minorWorldInterval) * minorWorldInterval
+    const hFirstMajor = Math.ceil(hContentLeft / majorWorldInterval) * majorWorldInterval
+    const tickBottom = worldTop + rulerThick
+
+    // Minor ticks
+    for (let wx = hFirstMinor; wx <= worldRight; wx += minorWorldInterval) {
+      // Skip positions that will be drawn as major ticks
+      const rem = Math.abs(((wx - hFirstMajor) % majorWorldInterval + majorWorldInterval) % majorWorldInterval)
+      if (rem < majorWorldInterval * 0.001) continue
+      canvas.drawLine(wx, tickBottom - rulerThick * 0.25, wx, tickBottom, tickPaint)
+    }
+
+    // Major ticks + labels
+    for (let wx = hFirstMajor; wx <= worldRight; wx += majorWorldInterval) {
+      canvas.drawLine(wx, tickBottom - rulerThick * 0.5, wx, tickBottom, tickPaint)
+      const label = formatLabel(wx / unitScale)
+      canvas.drawText(label, wx + 2 * invScale, worldTop + fontSizeW + 2 * invScale, textPaint, font)
+    }
+
+    // ─── Vertical ruler ticks ──────────────────────────────────────────────
+
+    const vContentTop = worldTop + rulerThick
+    const vFirstMinor = Math.ceil(vContentTop / minorWorldInterval) * minorWorldInterval
+    const vFirstMajor = Math.ceil(vContentTop / majorWorldInterval) * majorWorldInterval
+    const tickRight = worldLeft + rulerThick
+
+    // Minor ticks
+    for (let wy = vFirstMinor; wy <= worldBottom; wy += minorWorldInterval) {
+      const rem = Math.abs(((wy - vFirstMajor) % majorWorldInterval + majorWorldInterval) % majorWorldInterval)
+      if (rem < majorWorldInterval * 0.001) continue
+      canvas.drawLine(tickRight - rulerThick * 0.25, wy, tickRight, wy, tickPaint)
+    }
+
+    // Major ticks + labels (rotated -90° so text reads bottom-to-top)
+    for (let wy = vFirstMajor; wy <= worldBottom; wy += majorWorldInterval) {
+      canvas.drawLine(tickRight - rulerThick * 0.5, wy, tickRight, wy, tickPaint)
+
+      const label = formatLabel(wy / unitScale)
+      // Rotation matrix for -90° around (tx, ty) — maps local (x,y) to world (ty-x+tx, wy+... wait
+      // Row-major 3×3: [a,b,tx, c,d,ty, 0,0,1] → x'=a·x+b·y+tx, y'=c·x+d·y+ty
+      // For -90° rotation: a=0, b=1, c=-1, d=0
+      // Translate to (tx, ty) first, then rotate: net matrix = [0,1,tx, -1,0,ty, 0,0,1]
+      // local +x → world -y (upward): text glyphs flow upward ✓
+      // local +y → world +x (rightward, toward canvas interior): cap height faces canvas ✓
+      const tx = worldLeft + rulerThick * 0.5
+      const approxHalfWidth = label.length * fontSizeW * 0.35
+      canvas.save()
+      canvas.concat([0, 1, tx, -1, 0, wy, 0, 0, 1])
+      canvas.drawText(label, -approxHalfWidth, fontSizeW * 0.4, textPaint, font)
+      canvas.restore()
+    }
+
+    // Cleanup
+    bgPaint.delete()
+    borderPaint.delete()
+    tickPaint.delete()
+    textPaint.delete()
+    font.delete()
+  }
+}

--- a/packages/plugins/ruler/src/index.ts
+++ b/packages/plugins/ruler/src/index.ts
@@ -1,0 +1,2 @@
+export { RulerPlugin } from './RulerPlugin.js'
+export type { RulerPluginOptions, RulerColor } from './RulerPlugin.js'

--- a/packages/plugins/ruler/tests/RulerPlugin.test.ts
+++ b/packages/plugins/ruler/tests/RulerPlugin.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RulerPlugin } from '../src/RulerPlugin.js'
+import { Layer, BoundingBox } from '@nexvas/core'
+import type { StageInterface, FontManager, RenderPass, RenderContext, ViewportState } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeViewport(overrides: Partial<ViewportState> = {}): ViewportState & {
+  pan(dx: number, dy: number): void
+  zoom(factor: number, ox: number, oy: number): void
+  getState(): ViewportState
+  screenToWorld(sx: number, sy: number): { x: number; y: number }
+} {
+  const state: ViewportState = { x: 0, y: 0, scale: 1, width: 800, height: 600, ...overrides }
+  return {
+    ...state,
+    getState: () => state,
+    pan(dx: number, dy: number) { state.x += dx; state.y += dy },
+    zoom(factor: number) { state.scale *= factor },
+    screenToWorld(sx: number, sy: number) {
+      return { x: (sx - state.x) / state.scale, y: (sy - state.y) / state.scale }
+    },
+    panTo() {},
+    setScale() {},
+    reset() {},
+    setState() {},
+    setOptions() {},
+    setOnChange() {},
+    setSize() {},
+    fitToRect() {},
+    animateTo() {},
+    cancelAnimation() {},
+  }
+}
+
+function makeStage() {
+  const layer = new Layer()
+  const handlers = new Map<string, Set<(e: unknown) => void>>()
+  const passes: RenderPass[] = []
+  const vp = makeViewport()
+
+  const stage = {
+    id: 'test-stage',
+    canvasKit: {},
+    get layers() { return [layer] as unknown as readonly Layer[] },
+    viewport: vp,
+    fonts: {} as unknown as FontManager,
+    on(event: string, handler: (e: unknown) => void) {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    },
+    off(event: string, handler: (e: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+    },
+    emit(event: string, data: unknown) {
+      handlers.get(event)?.forEach((h) => h(data))
+    },
+    addRenderPass(pass: RenderPass) { passes.push(pass) },
+    removeRenderPass(pass: RenderPass) {
+      const i = passes.indexOf(pass)
+      if (i !== -1) passes.splice(i, 1)
+    },
+    getBoundingBox() { return new BoundingBox(0, 0, 800, 600) },
+    render() {},
+    markDirty: vi.fn(),
+    resize() {},
+    find: () => [],
+    findByType: () => [],
+    getObjectById: () => undefined,
+    registerObject: () => {},
+    getObjectLayer: () => null,
+    bringToFront: () => {},
+    sendToBack: () => {},
+    bringForward: () => {},
+    sendBackward: () => {},
+    groupObjects: () => { throw new Error('not implemented') },
+    ungroupObject: () => [],
+    batch(fn: () => void) { fn() },
+    _passes: passes,
+    _handlers: handlers,
+  } as unknown as StageInterface & { _passes: RenderPass[]; _handlers: Map<string, Set<(e: unknown) => void>> }
+
+  return { stage, vp, passes, handlers }
+}
+
+/** Minimal CanvasKit mock that records draw calls. */
+function makeCanvasKit() {
+  const drawCalls: string[] = []
+  const ck = {
+    Paint: class {
+      setStyle() {}
+      setColor() {}
+      setAntiAlias() {}
+      setStrokeWidth() {}
+      delete() {}
+    },
+    Font: class {
+      delete() {}
+    },
+    Color4f: (r: number, g: number, b: number, a: number) => new Float32Array([r, g, b, a]),
+    PaintStyle: { Fill: 'fill', Stroke: 'stroke' },
+  }
+  const skCanvas = {
+    drawRect() { drawCalls.push('drawRect') },
+    drawLine() { drawCalls.push('drawLine') },
+    drawText(str: string) { drawCalls.push(`drawText:${str}`) },
+    save: () => 1,
+    restore() {},
+    concat() {},
+  }
+  return { ck, skCanvas, drawCalls }
+}
+
+function makeRenderCtx(
+  ck: ReturnType<typeof makeCanvasKit>['ck'],
+  skCanvas: ReturnType<typeof makeCanvasKit>['skCanvas'],
+  stage: StageInterface,
+  vpOverrides: Partial<ViewportState> = {},
+): RenderContext {
+  const vp: ViewportState = { x: 0, y: 0, scale: 1, width: 800, height: 600, ...vpOverrides }
+  return {
+    skCanvas,
+    canvasKit: ck as unknown as RenderContext['canvasKit'],
+    fontManager: null,
+    pixelRatio: 1,
+    viewport: vp,
+    stage,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RulerPlugin', () => {
+  let stageEnv: ReturnType<typeof makeStage>
+
+  beforeEach(() => {
+    stageEnv = makeStage()
+  })
+
+  describe('install / uninstall', () => {
+    it('installs without throwing', () => {
+      const plugin = new RulerPlugin()
+      expect(() => plugin.install(stageEnv.stage)).not.toThrow()
+    })
+
+    it('registers a post-phase render pass on install', () => {
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      expect(stageEnv.passes).toHaveLength(1)
+      expect(stageEnv.passes[0]!.phase).toBe('post')
+    })
+
+    it('removes the render pass on uninstall', () => {
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      plugin.uninstall(stageEnv.stage)
+      expect(stageEnv.passes).toHaveLength(0)
+    })
+
+    it('uninstall is idempotent when called without prior install', () => {
+      const plugin = new RulerPlugin()
+      expect(() => plugin.uninstall(stageEnv.stage)).not.toThrow()
+    })
+
+    it('supports install → uninstall → reinstall', () => {
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      plugin.uninstall(stageEnv.stage)
+      plugin.install(stageEnv.stage)
+      expect(stageEnv.passes).toHaveLength(1)
+    })
+  })
+
+  describe('ruler:ready event', () => {
+    it('emits ruler:ready on install', () => {
+      const handler = vi.fn()
+      stageEnv.stage.on('ruler:ready', handler as unknown as Parameters<StageInterface['on']>[1])
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('ruler:ready payload contains the configured size', () => {
+      const received: unknown[] = []
+      stageEnv.stage.on('ruler:ready', (e) => received.push(e))
+      const plugin = new RulerPlugin({ size: 24 })
+      plugin.install(stageEnv.stage)
+      expect(received[0]).toEqual({ size: 24 })
+    })
+
+    it('ruler:ready uses default size of 20 when no options given', () => {
+      const received: unknown[] = []
+      stageEnv.stage.on('ruler:ready', (e) => received.push(e))
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      expect(received[0]).toEqual({ size: 20 })
+    })
+  })
+
+  describe('render pass', () => {
+    it('render pass runs without throwing with a valid context', () => {
+      const { ck, skCanvas } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      const ctx = makeRenderCtx(ck, skCanvas, stageEnv.stage)
+      expect(() => pass.render(ctx)).not.toThrow()
+    })
+
+    it('render pass skips drawing when skCanvas is null', () => {
+      const { ck } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      const ctx: RenderContext = {
+        skCanvas: null,
+        canvasKit: ck as unknown as RenderContext['canvasKit'],
+        fontManager: null,
+        pixelRatio: 1,
+        viewport: { x: 0, y: 0, scale: 1, width: 800, height: 600 },
+        stage: stageEnv.stage,
+      }
+      expect(() => pass.render(ctx)).not.toThrow()
+    })
+
+    it('draws background rects for both rulers', () => {
+      const { ck, skCanvas, drawCalls } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      pass.render(makeRenderCtx(ck, skCanvas, stageEnv.stage))
+      const rectCount = drawCalls.filter((c) => c === 'drawRect').length
+      // At minimum: horizontal + vertical backgrounds = 2 rects
+      expect(rectCount).toBeGreaterThanOrEqual(2)
+    })
+
+    it('draws tick lines for the rulers', () => {
+      const { ck, skCanvas, drawCalls } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      pass.render(makeRenderCtx(ck, skCanvas, stageEnv.stage))
+      const lineCount = drawCalls.filter((c) => c === 'drawLine').length
+      // At minimum: 2 separator lines + some tick marks
+      expect(lineCount).toBeGreaterThanOrEqual(2)
+    })
+
+    it('draws text labels for major ticks', () => {
+      const { ck, skCanvas, drawCalls } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      pass.render(makeRenderCtx(ck, skCanvas, stageEnv.stage))
+      const textCount = drawCalls.filter((c) => c.startsWith('drawText:')).length
+      expect(textCount).toBeGreaterThan(0)
+    })
+
+    it('renders at zoomed-in scale without throwing', () => {
+      const { ck, skCanvas } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      // scale=5 (zoomed in), pan offset
+      const ctx = makeRenderCtx(ck, skCanvas, stageEnv.stage, { x: -200, y: -100, scale: 5 })
+      expect(() => pass.render(ctx)).not.toThrow()
+    })
+
+    it('renders at zoomed-out scale without throwing', () => {
+      const { ck, skCanvas } = makeCanvasKit()
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      const ctx = makeRenderCtx(ck, skCanvas, stageEnv.stage, { scale: 0.1 })
+      expect(() => pass.render(ctx)).not.toThrow()
+    })
+  })
+
+  describe('options', () => {
+    it('accepts custom size', () => {
+      const plugin = new RulerPlugin({ size: 30 })
+      expect(() => plugin.install(stageEnv.stage)).not.toThrow()
+    })
+
+    it('accepts all unit options', () => {
+      const units: Array<'px' | 'pt' | 'mm' | 'cm' | 'in'> = ['px', 'pt', 'mm', 'cm', 'in']
+      for (const unit of units) {
+        const { ck, skCanvas } = makeCanvasKit()
+        const { stage, passes } = makeStage()
+        const plugin = new RulerPlugin({ unit })
+        plugin.install(stage)
+        expect(() => passes[0]!.render(makeRenderCtx(ck, skCanvas, stage))).not.toThrow()
+      }
+    })
+
+    it('accepts custom colors without throwing', () => {
+      const plugin = new RulerPlugin({
+        tickColor: { r: 1, g: 0, b: 0, a: 1 },
+        backgroundColor: { r: 0, g: 0, b: 1, a: 0.5 },
+        textColor: { r: 0, g: 1, b: 0, a: 1 },
+      })
+      const { ck, skCanvas } = makeCanvasKit()
+      plugin.install(stageEnv.stage)
+      expect(() => stageEnv.passes[0]!.render(makeRenderCtx(ck, skCanvas, stageEnv.stage))).not.toThrow()
+    })
+
+    it('accepts custom fontSize', () => {
+      const plugin = new RulerPlugin({ fontSize: 12 })
+      const { ck, skCanvas } = makeCanvasKit()
+      plugin.install(stageEnv.stage)
+      expect(() => stageEnv.passes[0]!.render(makeRenderCtx(ck, skCanvas, stageEnv.stage))).not.toThrow()
+    })
+  })
+
+  describe('render pass order', () => {
+    it('render pass order is high (draws on top)', () => {
+      const plugin = new RulerPlugin()
+      plugin.install(stageEnv.stage)
+      const pass = stageEnv.passes[0]!
+      expect(pass.order).toBeGreaterThanOrEqual(100)
+    })
+  })
+})

--- a/packages/plugins/ruler/tsconfig.json
+++ b/packages/plugins/ruler/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/plugins/ruler/vite.config.ts
+++ b/packages/plugins/ruler/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      name: 'CanvasFwPluginRuler',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: ['@nexvas/core'],
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+})

--- a/packages/plugins/ruler/vitest.config.ts
+++ b/packages/plugins/ruler/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@nexvas/plugin-ruler',
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
 
+  packages/plugins/ruler:
+    devDependencies:
+      '@nexvas/core':
+        specifier: workspace:*
+        version: link:../../core
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.1
+        version: 8.0.1(@types/node@12.20.55)(esbuild@0.21.5)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@12.20.55)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1)(vite@8.0.1(@types/node@12.20.55)(esbuild@0.21.5))
+
   packages/plugins/selection:
     devDependencies:
       '@nexvas/core':


### PR DESCRIPTION
### What was built:                                                                                                                                         
  - `packages/plugins/ruler/` — full plugin package (src, tests, package.json, tsconfig.json, vite.config.ts, vitest.config.ts)
  - `packages/core/src/types.ts` — 'ruler:ready': { size: number } added to StageEventMap

### How it works:
  - Draws horizontal (top) and vertical (left) ruler bands using a post-phase render pass at order 1000 (always on top)
  - Uses the world-space `invScale` technique — all ruler geometry is drawn in world coordinates scaled by `1/viewport.scale` so it appears at a fixed CSS
  pixel size regardless of zoom level
  - Adaptive major tick interval: targets ~60 screen pixels between ticks, picks a "nice" rounded value in display units, with 5 minor sub-divisions
  - Five display units: `px`, `pt`, `mm`, `cm`, `in` (96 DPI conversion constants)
  - Vertical labels are rotated −90° via a `canvas.concat` rotation matrix so they read bottom-to-top
  - Fires `ruler:ready` on install with the size payload so the app can inset the canvas element