### PR TITLE
Cache viewport culling rect in RenderContext - compute once in Stage.render() instead of per Layer

### DIFF
--- a/packages/core/src/Layer.ts
+++ b/packages/core/src/Layer.ts
@@ -259,10 +259,8 @@ export class Layer {
   render(ctx: RenderContext): void {
     if (!this.visible) return
 
-    const vp = ctx.viewport
-
     // Zero-size viewport (test/headless): skip R-tree culling, render all visible objects.
-    if (vp.width <= 0 || vp.height <= 0) {
+    if (ctx.cullingRect === null) {
       for (const obj of this._objects) {
         if (!obj.visible) continue
         try {
@@ -274,12 +272,7 @@ export class Layer {
       return
     }
 
-    const minX = -vp.x / vp.scale
-    const minY = -vp.y / vp.scale
-    const maxX = minX + vp.width / vp.scale
-    const maxY = minY + vp.height / vp.scale
-
-    const candidates = this._index.search({ minX, minY, maxX, maxY })
+    const candidates = this._index.search(ctx.cullingRect)
     if (candidates.length === 0) return
 
     // Build set of in-viewport visible objects for O(1) lookup while iterating _objects in z-order.

--- a/packages/core/src/Stage.ts
+++ b/packages/core/src/Stage.ts
@@ -527,6 +527,16 @@ export class Stage implements StageInterface {
     skCanvas.translate(vp.x, vp.y)
     skCanvas.scale(vp.scale, vp.scale)
 
+    const cullingRect =
+      vp.width > 0 && vp.height > 0
+        ? {
+            minX: -vp.x / vp.scale,
+            minY: -vp.y / vp.scale,
+            maxX: (-vp.x + vp.width) / vp.scale,
+            maxY: (-vp.y + vp.height) / vp.scale,
+          }
+        : null
+
     const ctx: RenderContext = {
       skCanvas,
       canvasKit: this.canvasKit,
@@ -534,6 +544,7 @@ export class Stage implements StageInterface {
       pixelRatio: this._pixelRatio,
       viewport: vp,
       stage: this,
+      cullingRect,
     }
 
     // Pre-render passes (e.g. grid background)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -120,6 +120,12 @@ export interface RenderContext {
   viewport: ViewportState
   /** The stage — used by Connector to resolve object port positions at render time. */
   stage: StageInterface
+  /**
+   * Pre-computed world-space culling rect for the current viewport.
+   * Null when the viewport is zero-size (headless/test). Computed once in
+   * Stage.render() so multiple layers don't redundantly recalculate it.
+   */
+  cullingRect: { minX: number; minY: number; maxX: number; maxY: number } | null
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/Layer.test.ts
+++ b/packages/core/tests/Layer.test.ts
@@ -16,6 +16,10 @@ function makeCtx(vpX = 0, vpY = 0, scale = 1, width = 800, height = 600): Render
     pixelRatio: 1,
     viewport: { x: vpX, y: vpY, scale, width, height },
     stage: {} as unknown as StageInterface,
+    cullingRect:
+      width > 0 && height > 0
+        ? { minX: -vpX / scale, minY: -vpY / scale, maxX: (-vpX + width) / scale, maxY: (-vpY + height) / scale }
+        : null,
   }
 }
 

--- a/packages/plugins/export/src/ExportPlugin.ts
+++ b/packages/plugins/export/src/ExportPlugin.ts
@@ -231,6 +231,10 @@ export class ExportPlugin implements Plugin {
         width: region.width,
         height: region.height,
       },
+      cullingRect:
+        region.width > 0 && region.height > 0
+          ? { minX: region.x, minY: region.y, maxX: region.x + region.width, maxY: region.y + region.height }
+          : null,
     }
 
     for (const layer of this._stage.layers as unknown as Layer[]) {


### PR DESCRIPTION
The culling rect ({ minX, minY, maxX, maxY }) defines which world-space area is visible on screen. Before this change, every Layer.render()             
  independently recomputed those four values from the viewport state.
                                                                                                                                                          
  Before:
  Stage.render()                                                                                                                                          
    └─ Layer[0].render()  → computes minX/minY/maxX/maxY
    └─ Layer[1].render()  → computes minX/minY/maxX/maxY  (same values, redundant)
    └─ Layer[2].render()  → computes minX/minY/maxX/maxY  (redundant again)

  After:
  Stage.render()
    → computes cullingRect once
    └─ Layer[0].render()  → reads ctx.cullingRect
    └─ Layer[1].render()  → reads ctx.cullingRect
    └─ Layer[2].render()  → reads ctx.cullingRect

  The practical benefit is small but clean: most apps have 2–4 layers, so you save 1–3 redundant div/multiply operations per frame. At 60fps that's
  negligible on its own.

  The real value is architectural:
  - Correctness guarantee - all layers use the exact same culling rect per frame. If you computed it independently with floating point, you could
  theoretically get a 1-ULP difference between layers (not a real bug today, but a category of bug that's now impossible).
  - Foundation for future work - §5.8 (offscreen layer caching) needs the culling rect to be a first-class concept in RenderContext to decide whether a
  cached layer surface needs re-blitting. It needs to be there before it can be used.
  - One source of truth - the formula -vp.x / vp.scale lived in Layer.ts before; now it lives only in Stage.ts where viewport state is owned.
