### PR TITLE
add CustomEditOptions overload to startEditing() for custom object types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -245,6 +245,12 @@ export interface StageEventMap extends ObjectEventMap {
    * the canvas element by this amount on the top and left edges.
    */
   'ruler:ready': { size: number }
+  /** Fired by TextEditPlugin when inline editing begins on an object. */
+  'textedit:start': { object: BaseObject }
+  /** Fired by TextEditPlugin when the user commits an edit (Enter or blur). */
+  'textedit:commit': { object: BaseObject; oldText: string; newText: string }
+  /** Fired by TextEditPlugin when the user cancels an edit (Escape). */
+  'textedit:cancel': { object: BaseObject }
 }
 
 // ---------------------------------------------------------------------------
@@ -370,6 +376,8 @@ export interface StrokeStyle {
 export interface StageInterface {
   readonly id: string
   readonly canvasKit: CanvasKitLike
+  /** The HTML canvas element owned by this stage. */
+  readonly canvas: HTMLCanvasElement
   readonly layers: readonly Layer[]
   readonly viewport: Viewport
   readonly fonts: FontManager

--- a/packages/plugins/text-edit/package.json
+++ b/packages/plugins/text-edit/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nexvas/plugin-text-edit",
+  "version": "0.1.0",
+  "description": "Inline text editing plugin for NexVas",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc --emitDeclarationOnly --declaration",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexvas/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@nexvas/core": "workspace:*",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0",
+    "jsdom": "^29.0.1"
+  }
+}

--- a/packages/plugins/text-edit/src/TextEditPlugin.ts
+++ b/packages/plugins/text-edit/src/TextEditPlugin.ts
@@ -1,0 +1,410 @@
+import type {
+  Plugin,
+  StageInterface,
+  CanvasPointerEvent,
+  BaseObject,
+} from '@nexvas/core'
+import { Text } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options passed to `startEditing()` when editing a custom (non-Text) object.
+ * The plugin manages the textarea overlay; the caller supplies text get/set
+ * callbacks and optional style hints.
+ */
+export interface CustomEditOptions {
+  /** Return the current text value to pre-fill the textarea. */
+  getText: () => string
+  /**
+   * Called when the user commits the edit (Enter / blur).
+   * The plugin wraps this call in `stage.batch()` so HistoryPlugin records
+   * one undo entry.
+   */
+  onCommit: (newText: string) => void
+  /** Called when the user cancels the edit (Escape). No undo entry is created. */
+  onCancel?: () => void
+  /** Optional style hints for sizing and font-matching the textarea overlay. */
+  style?: {
+    /** World-space left edge of the edit area. */
+    x: number
+    /** World-space top edge of the edit area. */
+    y: number
+    /** World-space width of the edit area. */
+    width: number
+    /** World-space height of the edit area. */
+    height: number
+    fontSize?: number
+    fontFamily?: string
+    /** CSS color string for the text, e.g. `'#1a1a1a'`. */
+    color?: string
+    align?: 'left' | 'center' | 'right'
+  }
+}
+
+/**
+ * Type augmentation for accessing TextEditPlugin through the stage.
+ * @example
+ * const edit = (stage as TextEditPluginAPI).textEdit
+ */
+export interface TextEditPluginAPI {
+  textEdit: TextEditPlugin
+}
+
+// ---------------------------------------------------------------------------
+// Internal session types
+// ---------------------------------------------------------------------------
+
+interface TextSession {
+  kind: 'text'
+  object: Text
+  originalText: string
+}
+
+interface CustomSession {
+  kind: 'custom'
+  object: BaseObject
+  options: CustomEditOptions
+  originalText: string
+}
+
+type EditSession = TextSession | CustomSession
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * TextEditPlugin — inline text editing via a DOM textarea overlay.
+ *
+ * Automatically triggers on double-click of built-in {@link Text} objects.
+ * Custom object types can opt in by calling `startEditing(object, options)`.
+ *
+ * Events fired on stage:
+ * - `textedit:start`  — editing began
+ * - `textedit:commit` — user committed (Enter / click-outside)
+ * - `textedit:cancel` — user cancelled (Escape)
+ */
+export class TextEditPlugin implements Plugin {
+  readonly name = 'text-edit'
+  readonly version = '0.1.0'
+
+  private _stage: StageInterface | null = null
+  private _session: EditSession | null = null
+  private _textarea: HTMLTextAreaElement | null = null
+
+  private _onDblClick: (e: CanvasPointerEvent) => void
+  private _onTextareaKeyDown: (e: KeyboardEvent) => void
+  private _onTextareaBlur: () => void
+
+  constructor() {
+    this._onDblClick = this._handleDblClick.bind(this)
+    this._onTextareaKeyDown = this._handleTextareaKeyDown.bind(this)
+    this._onTextareaBlur = this._handleTextareaBlur.bind(this)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plugin lifecycle
+  // ---------------------------------------------------------------------------
+
+  install(stage: StageInterface): void {
+    this._stage = stage
+    ;(stage as unknown as TextEditPluginAPI).textEdit = this
+    stage.on('dblclick', this._onDblClick)
+  }
+
+  uninstall(stage: StageInterface): void {
+    stage.off('dblclick', this._onDblClick)
+    this._cancelEdit()
+    this._stage = null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /** Returns true while an inline edit session is active. */
+  isEditing(): boolean {
+    return this._session !== null
+  }
+
+  /**
+   * Begin inline editing.
+   *
+   * @overload Editing a built-in {@link Text} object — reads font/position
+   * from the object itself.
+   * @param textObject - The Text object to edit.
+   */
+  startEditing(textObject: Text): void
+  /**
+   * Begin inline editing for a custom object type.
+   *
+   * @overload Editing any {@link BaseObject} via caller-supplied callbacks.
+   * @param object - The object to hide while editing.
+   * @param options - Text callbacks and optional textarea style hints.
+   */
+  startEditing(object: BaseObject, options: CustomEditOptions): void
+  startEditing(object: Text | BaseObject, options?: CustomEditOptions): void {
+    const stage = this._stage
+    if (!stage) return
+
+    // Commit any active session before starting a new one.
+    if (this._session !== null) this._commitEdit()
+
+    if (options !== undefined) {
+      this._startCustomEdit(object, options)
+    } else {
+      if (!(object instanceof Text)) return
+      this._startTextEdit(object)
+    }
+  }
+
+  /**
+   * Commit the active edit session (same as pressing Enter / clicking outside).
+   * No-op if no session is active.
+   */
+  stopEditing(): void {
+    this._commitEdit()
+  }
+
+  /**
+   * Cancel the active edit session (same as pressing Escape).
+   * No-op if no session is active.
+   */
+  cancelEditing(): void {
+    this._cancelEdit()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Edit session helpers
+  // ---------------------------------------------------------------------------
+
+  private _startTextEdit(obj: Text): void {
+    const stage = this._stage!
+    const session: TextSession = {
+      kind: 'text',
+      object: obj,
+      originalText: obj.text,
+    }
+    this._session = session
+
+    const screenPos = stage.viewport.worldToScreen(obj.x, obj.y)
+    const scale = stage.viewport.scale
+    this._createTextarea({
+      screenX: screenPos.x,
+      screenY: screenPos.y,
+      width: obj.width * scale,
+      height: obj.height * scale,
+      fontSize: obj.fontSize * scale,
+      fontFamily: obj.fontFamily,
+      color: undefined,
+      align: obj.align as 'left' | 'center' | 'right',
+      initialValue: obj.text,
+    })
+
+    obj.visible = false
+    stage.markDirty()
+    stage.emit('textedit:start', { object: obj })
+  }
+
+  private _startCustomEdit(obj: BaseObject, options: CustomEditOptions): void {
+    const stage = this._stage!
+    const session: CustomSession = {
+      kind: 'custom',
+      object: obj,
+      options,
+      originalText: options.getText(),
+    }
+    this._session = session
+
+    const s = options.style
+    let screenX = 0
+    let screenY = 0
+    let width = 200
+    let height = 40
+    let fontSize = 16
+    let fontFamily: string | undefined
+    let color: string | undefined
+    let align: 'left' | 'center' | 'right' | undefined
+
+    if (s) {
+      const screenPos = stage.viewport.worldToScreen(s.x, s.y)
+      const scale = stage.viewport.scale
+      screenX = screenPos.x
+      screenY = screenPos.y
+      width = s.width * scale
+      height = s.height * scale
+      fontSize = (s.fontSize ?? 16) * scale
+      fontFamily = s.fontFamily
+      color = s.color
+      align = s.align
+    }
+
+    this._createTextarea({
+      screenX,
+      screenY,
+      width,
+      height,
+      fontSize,
+      fontFamily,
+      color,
+      align,
+      initialValue: session.originalText,
+    })
+
+    obj.visible = false
+    stage.markDirty()
+    stage.emit('textedit:start', { object: obj })
+  }
+
+  private _createTextarea(opts: {
+    screenX: number
+    screenY: number
+    width: number
+    height: number
+    fontSize: number
+    fontFamily: string | undefined
+    color: string | undefined
+    align: 'left' | 'center' | 'right' | undefined
+    initialValue: string
+  }): void {
+    if (typeof document === 'undefined') return
+
+    const stage = this._stage!
+    const canvasRect = stage.canvas.getBoundingClientRect()
+
+    const ta = document.createElement('textarea')
+    ta.value = opts.initialValue
+    // Position fixed so scroll offsets don't affect placement.
+    ta.style.cssText = [
+      'position:fixed',
+      `left:${canvasRect.left + opts.screenX}px`,
+      `top:${canvasRect.top + opts.screenY}px`,
+      `width:${Math.max(opts.width, 1)}px`,
+      `height:${Math.max(opts.height, 1)}px`,
+      `font-size:${opts.fontSize}px`,
+      `font-family:${opts.fontFamily ?? 'Noto Sans, sans-serif'}`,
+      `color:${opts.color ?? 'inherit'}`,
+      `text-align:${opts.align ?? 'left'}`,
+      'border:none',
+      'outline:none',
+      'background:transparent',
+      'resize:none',
+      'overflow:hidden',
+      'padding:0',
+      'margin:0',
+      'box-sizing:border-box',
+      'z-index:9999',
+    ].join(';')
+
+    ta.addEventListener('keydown', this._onTextareaKeyDown)
+    ta.addEventListener('blur', this._onTextareaBlur)
+
+    document.body.appendChild(ta)
+    // Select all text so the user can immediately replace it.
+    ta.focus()
+    ta.select()
+
+    this._textarea = ta
+  }
+
+  private _removeTextarea(): void {
+    const ta = this._textarea
+    if (!ta) return
+    ta.removeEventListener('keydown', this._onTextareaKeyDown)
+    ta.removeEventListener('blur', this._onTextareaBlur)
+    ta.parentNode?.removeChild(ta)
+    this._textarea = null
+  }
+
+  private _commitEdit(): void {
+    const session = this._session
+    const stage = this._stage
+    if (!session || !stage) return
+
+    const newText = this._textarea?.value ?? ''
+    // Remove textarea first to prevent the blur handler from re-entering.
+    this._removeTextarea()
+    this._session = null
+
+    const obj = session.object
+
+    if (session.kind === 'text') {
+      const oldText = session.originalText
+      stage.batch(() => {
+        session.object.text = newText
+      })
+      obj.visible = true
+      stage.markDirty()
+      stage.emit('textedit:commit', { object: obj, oldText, newText })
+    } else {
+      const oldText = session.originalText
+      stage.batch(() => {
+        session.options.onCommit(newText)
+      })
+      obj.visible = true
+      stage.markDirty()
+      stage.emit('textedit:commit', { object: obj, oldText, newText })
+    }
+  }
+
+  private _cancelEdit(): void {
+    const session = this._session
+    const stage = this._stage
+    if (!session) return
+
+    this._removeTextarea()
+    this._session = null
+
+    const obj = session.object
+    obj.visible = true
+    stage?.markDirty()
+
+    if (session.kind === 'custom') {
+      session.options.onCancel?.()
+    }
+
+    stage?.emit('textedit:cancel', { object: obj })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  private _handleDblClick(e: CanvasPointerEvent): void {
+    const stage = this._stage
+    if (!stage) return
+
+    // Find the topmost object at the click position.
+    const { world } = e
+    let hit: BaseObject | null = null
+    const layers = stage.layers
+    for (let i = layers.length - 1; i >= 0; i--) {
+      hit = layers[i]!.hitTest(world.x, world.y)
+      if (hit !== null) break
+    }
+
+    if (hit instanceof Text) {
+      this.startEditing(hit)
+    }
+  }
+
+  private _handleTextareaKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      this._commitEdit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      this._cancelEdit()
+    }
+  }
+
+  private _handleTextareaBlur(): void {
+    // Only commit if the session is still active (Escape clears session first).
+    if (this._session !== null) {
+      this._commitEdit()
+    }
+  }
+}

--- a/packages/plugins/text-edit/src/index.ts
+++ b/packages/plugins/text-edit/src/index.ts
@@ -1,0 +1,2 @@
+export { TextEditPlugin } from './TextEditPlugin.js'
+export type { CustomEditOptions, TextEditPluginAPI } from './TextEditPlugin.js'

--- a/packages/plugins/text-edit/tests/TextEditPlugin.test.ts
+++ b/packages/plugins/text-edit/tests/TextEditPlugin.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { TextEditPlugin, type CustomEditOptions, type TextEditPluginAPI } from '../src/TextEditPlugin.js'
+import { Text } from '@nexvas/core'
+import type { StageInterface, Viewport, FontManager, BaseObject, Layer, CanvasPointerEvent } from '@nexvas/core'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type StageEventHandler = (data: unknown) => void
+
+function makeCanvas(): HTMLCanvasElement {
+  const c = document.createElement('canvas')
+  c.width = 800
+  c.height = 600
+  // jsdom getBoundingClientRect returns zeros by default
+  vi.spyOn(c, 'getBoundingClientRect').mockReturnValue({
+    left: 10, top: 20, right: 810, bottom: 620,
+    width: 800, height: 600, x: 10, y: 20,
+    toJSON: () => ({}),
+  })
+  return c
+}
+
+function makeViewport(): Viewport {
+  return {
+    x: 0,
+    y: 0,
+    scale: 1,
+    worldToScreen: (wx: number, wy: number) => ({ x: wx, y: wy }),
+    screenToWorld: (sx: number, sy: number) => ({ x: sx, y: sy }),
+    getState: () => ({ x: 0, y: 0, scale: 1, width: 800, height: 600 }),
+  } as unknown as Viewport
+}
+
+function makeStage(overrides: { hitResult?: BaseObject | null } = {}): StageInterface & {
+  _handlers: Record<string, StageEventHandler[]>
+  _batchCalls: number
+} {
+  const handlers: Record<string, StageEventHandler[]> = {}
+  let batchCalls = 0
+
+  const layer: Layer = {
+    hitTest: vi.fn(() => overrides.hitResult ?? null),
+  } as unknown as Layer
+
+  return {
+    id: 'test-stage',
+    canvasKit: {},
+    canvas: makeCanvas(),
+    layers: [layer],
+    viewport: makeViewport(),
+    fonts: {} as unknown as FontManager,
+    on: vi.fn((event: string, handler: StageEventHandler) => {
+      ;(handlers[event] ??= []).push(handler)
+    }),
+    off: vi.fn((event: string, handler: StageEventHandler) => {
+      handlers[event] = (handlers[event] ?? []).filter((h) => h !== handler)
+    }),
+    addRenderPass: vi.fn(),
+    removeRenderPass: vi.fn(),
+    getBoundingBox: vi.fn(),
+    render: vi.fn(),
+    markDirty: vi.fn(),
+    emit: vi.fn((event: string, data: unknown) => {
+      for (const h of handlers[event] ?? []) h(data)
+    }),
+    resize: vi.fn(),
+    batch: vi.fn((fn: () => void) => {
+      batchCalls++
+      fn()
+    }),
+    find: vi.fn(),
+    findByType: vi.fn(),
+    getObjectById: vi.fn(),
+    registerObject: vi.fn(),
+    getObjectLayer: vi.fn(),
+    bringToFront: vi.fn(),
+    sendToBack: vi.fn(),
+    bringForward: vi.fn(),
+    sendBackward: vi.fn(),
+    groupObjects: vi.fn(),
+    ungroupObject: vi.fn(),
+    _handlers: handlers,
+    get _batchCalls() { return batchCalls },
+  } as unknown as StageInterface & { _handlers: Record<string, StageEventHandler[]>; _batchCalls: number }
+}
+
+function makeDblClickEvent(worldX = 0, worldY = 0): CanvasPointerEvent {
+  return {
+    world: { x: worldX, y: worldY },
+    screen: { x: worldX, y: worldY },
+    originalEvent: new MouseEvent('dblclick'),
+    stopped: false,
+    stopPropagation() { this.stopped = true },
+  }
+}
+
+function makeTextObject(props: Partial<{ x: number; y: number; width: number; height: number; text: string }> = {}): Text {
+  const t = new Text({
+    x: props.x ?? 10,
+    y: props.y ?? 20,
+    width: props.width ?? 100,
+    height: props.height ?? 30,
+    text: props.text ?? 'Hello',
+    fontSize: 16,
+  })
+  return t
+}
+
+function makeCustomOpts(overrides: Partial<CustomEditOptions> = {}): CustomEditOptions & {
+  commitCalls: string[]
+  cancelCalled: boolean
+} {
+  const commitCalls: string[] = []
+  let cancelCalled = false
+  return {
+    getText: () => 'custom text',
+    onCommit: vi.fn((t: string) => { commitCalls.push(t) }) as unknown as (t: string) => void,
+    onCancel: vi.fn(() => { cancelCalled = true }),
+    style: { x: 5, y: 10, width: 120, height: 40, fontSize: 14, fontFamily: 'Arial', color: '#333', align: 'left' },
+    commitCalls,
+    get cancelCalled() { return cancelCalled },
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TextEditPlugin', () => {
+  let plugin: TextEditPlugin
+  let stage: ReturnType<typeof makeStage>
+
+  beforeEach(() => {
+    plugin = new TextEditPlugin()
+    stage = makeStage()
+    plugin.install(stage)
+  })
+
+  afterEach(() => {
+    plugin.uninstall(stage)
+  })
+
+  // -------------------------------------------------------------------------
+  // Install / uninstall
+  // -------------------------------------------------------------------------
+
+  it('installs textEdit accessor on stage', () => {
+    expect((stage as unknown as TextEditPluginAPI).textEdit).toBe(plugin)
+  })
+
+  it('registers dblclick handler on install', () => {
+    expect(stage.on).toHaveBeenCalledWith('dblclick', expect.any(Function))
+  })
+
+  it('deregisters dblclick handler on uninstall', () => {
+    plugin.uninstall(stage)
+    expect(stage.off).toHaveBeenCalledWith('dblclick', expect.any(Function))
+    // Re-install for afterEach cleanup
+    plugin.install(stage)
+  })
+
+  // -------------------------------------------------------------------------
+  // isEditing()
+  // -------------------------------------------------------------------------
+
+  it('isEditing() returns false before any edit', () => {
+    expect(plugin.isEditing()).toBe(false)
+  })
+
+  it('isEditing() returns true while Text edit is active', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    expect(plugin.isEditing()).toBe(true)
+  })
+
+  it('isEditing() returns true while custom edit is active', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    expect(plugin.isEditing()).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // Text object — startEditing
+  // -------------------------------------------------------------------------
+
+  it('hides Text object and marks dirty on startEditing', () => {
+    const text = makeTextObject({ text: 'Hi' })
+    plugin.startEditing(text)
+    expect(text.visible).toBe(false)
+    expect(stage.markDirty).toHaveBeenCalled()
+  })
+
+  it('fires textedit:start with the Text object', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    expect(stage.emit).toHaveBeenCalledWith('textedit:start', { object: text })
+  })
+
+  it('creates a textarea in the DOM when editing a Text object', () => {
+    const text = makeTextObject({ text: 'world' })
+    plugin.startEditing(text)
+    const ta = document.querySelector('textarea')
+    expect(ta).not.toBeNull()
+    expect(ta!.value).toBe('world')
+  })
+
+  // -------------------------------------------------------------------------
+  // Text object — commit
+  // -------------------------------------------------------------------------
+
+  it('commit via stopEditing() restores visibility and updates text', () => {
+    const text = makeTextObject({ text: 'old' })
+    plugin.startEditing(text)
+
+    const ta = document.querySelector('textarea')!
+    ta.value = 'new text'
+    plugin.stopEditing()
+
+    expect(text.visible).toBe(true)
+    expect(text.text).toBe('new text')
+    expect(plugin.isEditing()).toBe(false)
+  })
+
+  it('commit wraps Text mutation in stage.batch()', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    plugin.stopEditing()
+    expect(stage.batch).toHaveBeenCalledOnce()
+  })
+
+  it('fires textedit:commit with oldText and newText for Text object', () => {
+    const text = makeTextObject({ text: 'original' })
+    plugin.startEditing(text)
+    const ta = document.querySelector('textarea')!
+    ta.value = 'updated'
+    plugin.stopEditing()
+
+    expect(stage.emit).toHaveBeenCalledWith('textedit:commit', {
+      object: text,
+      oldText: 'original',
+      newText: 'updated',
+    })
+  })
+
+  it('removes textarea from DOM after commit', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    expect(document.querySelector('textarea')).not.toBeNull()
+    plugin.stopEditing()
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // Text object — cancel
+  // -------------------------------------------------------------------------
+
+  it('cancel via cancelEditing() restores visibility, does not update text', () => {
+    const text = makeTextObject({ text: 'original' })
+    plugin.startEditing(text)
+    const ta = document.querySelector('textarea')!
+    ta.value = 'changed'
+    plugin.cancelEditing()
+
+    expect(text.visible).toBe(true)
+    expect(text.text).toBe('original')
+    expect(plugin.isEditing()).toBe(false)
+  })
+
+  it('cancel does not call stage.batch()', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    vi.mocked(stage.batch).mockClear()
+    plugin.cancelEditing()
+    expect(stage.batch).not.toHaveBeenCalled()
+  })
+
+  it('fires textedit:cancel for Text object', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    plugin.cancelEditing()
+    expect(stage.emit).toHaveBeenCalledWith('textedit:cancel', { object: text })
+  })
+
+  it('removes textarea from DOM after cancel', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    plugin.cancelEditing()
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // Keyboard — Enter commits, Escape cancels
+  // -------------------------------------------------------------------------
+
+  it('Enter key in textarea commits the edit', () => {
+    const text = makeTextObject({ text: 'before' })
+    plugin.startEditing(text)
+    const ta = document.querySelector('textarea')!
+    ta.value = 'after'
+    ta.dispatchEvent(Object.assign(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })))
+    expect(text.text).toBe('after')
+    expect(plugin.isEditing()).toBe(false)
+  })
+
+  it('Shift+Enter does NOT commit (allows newline)', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    document.querySelector('textarea')!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true }),
+    )
+    expect(plugin.isEditing()).toBe(true)
+  })
+
+  it('Escape key in textarea cancels the edit', () => {
+    const text = makeTextObject({ text: 'orig' })
+    plugin.startEditing(text)
+    const ta = document.querySelector('textarea')!
+    ta.value = 'changed'
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    expect(text.text).toBe('orig')
+    expect(plugin.isEditing()).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // Custom object — startEditing
+  // -------------------------------------------------------------------------
+
+  it('hides custom object and marks dirty on startEditing', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    expect(obj.visible).toBe(false)
+    expect(stage.markDirty).toHaveBeenCalled()
+  })
+
+  it('fires textedit:start with custom object', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    expect(stage.emit).toHaveBeenCalledWith('textedit:start', { object: obj })
+  })
+
+  it('pre-fills textarea with getText() result', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    expect(document.querySelector('textarea')!.value).toBe('custom text')
+  })
+
+  it('isEditing() returns true during custom edit', () => {
+    const obj = makeTextObject()
+    plugin.startEditing(obj, makeCustomOpts())
+    expect(plugin.isEditing()).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // Custom object — commit
+  // -------------------------------------------------------------------------
+
+  it('commit calls onCommit wrapped in stage.batch()', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    const ta = document.querySelector('textarea')!
+    ta.value = 'committed'
+    plugin.stopEditing()
+
+    expect(stage.batch).toHaveBeenCalledOnce()
+    expect(opts.onCommit).toHaveBeenCalledWith('committed')
+  })
+
+  it('commit restores custom object visibility', () => {
+    const obj = makeTextObject()
+    plugin.startEditing(obj, makeCustomOpts())
+    plugin.stopEditing()
+    expect(obj.visible).toBe(true)
+    expect(plugin.isEditing()).toBe(false)
+  })
+
+  it('fires textedit:commit with oldText and newText for custom object', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()  // getText returns 'custom text'
+    plugin.startEditing(obj, opts)
+    const ta = document.querySelector('textarea')!
+    ta.value = 'edited'
+    plugin.stopEditing()
+
+    expect(stage.emit).toHaveBeenCalledWith('textedit:commit', {
+      object: obj,
+      oldText: 'custom text',
+      newText: 'edited',
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Custom object — cancel
+  // -------------------------------------------------------------------------
+
+  it('cancel calls onCancel callback', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    plugin.cancelEditing()
+    expect(opts.onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('cancel does not call onCommit or stage.batch()', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    vi.mocked(stage.batch).mockClear()
+    plugin.cancelEditing()
+    expect(opts.onCommit).not.toHaveBeenCalled()
+    expect(stage.batch).not.toHaveBeenCalled()
+  })
+
+  it('cancel restores custom object visibility', () => {
+    const obj = makeTextObject()
+    plugin.startEditing(obj, makeCustomOpts())
+    plugin.cancelEditing()
+    expect(obj.visible).toBe(true)
+  })
+
+  it('fires textedit:cancel for custom object', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    plugin.cancelEditing()
+    expect(stage.emit).toHaveBeenCalledWith('textedit:cancel', { object: obj })
+  })
+
+  it('stopEditing() on custom object acts as commit', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    document.querySelector('textarea')!.value = 'stop result'
+    plugin.stopEditing()
+    expect(opts.onCommit).toHaveBeenCalledWith('stop result')
+    expect(obj.visible).toBe(true)
+  })
+
+  it('cancelEditing() on custom object acts as cancel', () => {
+    const obj = makeTextObject()
+    const opts = makeCustomOpts()
+    plugin.startEditing(obj, opts)
+    plugin.cancelEditing()
+    expect(opts.onCancel).toHaveBeenCalled()
+    expect(opts.onCommit).not.toHaveBeenCalled()
+    expect(obj.visible).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // dblclick auto-trigger on Text objects
+  // -------------------------------------------------------------------------
+
+  it('dblclick on a Text object starts editing it', () => {
+    const text = makeTextObject()
+    const stageWithHit = makeStage({ hitResult: text as unknown as BaseObject })
+    plugin.uninstall(stage)
+    plugin.install(stageWithHit)
+
+    const dblclick = stageWithHit._handlers['dblclick']?.[0]
+    dblclick?.(makeDblClickEvent(text.x, text.y))
+
+    expect(text.visible).toBe(false)
+    expect(plugin.isEditing()).toBe(true)
+
+    plugin.uninstall(stageWithHit)
+    plugin.install(stage)
+  })
+
+  it('dblclick on a non-Text object does not start editing', () => {
+    // BaseObject that is NOT a Text
+    const obj = { hitTest: vi.fn() } as unknown as BaseObject
+    const stageWithHit = makeStage({ hitResult: obj })
+    plugin.uninstall(stage)
+    plugin.install(stageWithHit)
+
+    const dblclick = stageWithHit._handlers['dblclick']?.[0]
+    dblclick?.(makeDblClickEvent(0, 0))
+
+    expect(plugin.isEditing()).toBe(false)
+    plugin.uninstall(stageWithHit)
+    plugin.install(stage)
+  })
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  it('starting a new edit while already editing commits the previous edit', () => {
+    const text1 = makeTextObject({ text: 'first' })
+    const text2 = makeTextObject({ text: 'second' })
+    plugin.startEditing(text1)
+    // Change first textarea
+    document.querySelector('textarea')!.value = 'modified'
+    plugin.startEditing(text2)
+    // First edit should be committed
+    expect(text1.text).toBe('modified')
+    expect(text1.visible).toBe(true)
+    // Second edit is now active
+    expect(plugin.isEditing()).toBe(true)
+    expect(text2.visible).toBe(false)
+    plugin.cancelEditing()
+  })
+
+  it('stopEditing() is a no-op when not editing', () => {
+    expect(() => plugin.stopEditing()).not.toThrow()
+  })
+
+  it('cancelEditing() is a no-op when not editing', () => {
+    expect(() => plugin.cancelEditing()).not.toThrow()
+  })
+
+  it('uninstall cancels active edit without throwing', () => {
+    const text = makeTextObject()
+    plugin.startEditing(text)
+    expect(() => plugin.uninstall(stage)).not.toThrow()
+    expect(text.visible).toBe(true)
+    expect(plugin.isEditing()).toBe(false)
+    // Re-install for afterEach
+    plugin.install(stage)
+  })
+})

--- a/packages/plugins/text-edit/tsconfig.json
+++ b/packages/plugins/text-edit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/plugins/text-edit/vite.config.ts
+++ b/packages/plugins/text-edit/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      name: 'CanvasFwPluginTextEdit',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: ['@nexvas/core'],
+    },
+    sourcemap: true,
+    target: 'es2020',
+  },
+})

--- a/packages/plugins/text-edit/vitest.config.ts
+++ b/packages/plugins/text-edit/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@nexvas/plugin-text-edit',
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
Core changes (packages/core/src/types.ts):                                                                                                              
  - Added readonly canvas: HTMLCanvasElement to StageInterface (Stage already had it, interface just didn't expose it)
  - Added textedit:start, textedit:commit, textedit:cancel to StageEventMap

  Plugin (packages/plugins/text-edit/):
  - Created the full plugin from scratch: package.json, tsconfig.json, vite.config.ts, vitest.config.ts, src/TextEditPlugin.ts, src/index.ts
  - startEditing(Text) — existing path: reads font/size/position from the Text object, positions textarea, commits via stage.batch(() => obj.text =
  newValue)
  - startEditing(BaseObject, CustomEditOptions) — new path: uses options.style for textarea sizing/position, calls stage.batch(() =>
  options.onCommit(text)) on commit, calls options.onCancel?.() on Escape
  - Both paths: hide object → show textarea → Enter/blur commits, Escape cancels → restore visibility → fire event
  - dblclick on Text objects auto-triggers editing
  - stopEditing() / cancelEditing() / isEditing() public API